### PR TITLE
Install package as wheel inside Nox sessions

### DIFF
--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 select = ANN,B,B9,BLK,C,D,DAR,E,F,I,S,W
-ignore = E203,E501,W503
+ignore = ANN101,E203,E501,W503
 max-line-length = 80
 max-complexity = 10
 application-import-names = {{cookiecutter.package_name}},tests

--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -3,6 +3,7 @@
 /.nox/
 /.python-version
 /.pytype/
+/dist/
 /docs/_build/
 /src/*.egg-info/
 __pycache__/

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -1,6 +1,7 @@
 """Nox sessions."""
+import contextlib
 import tempfile
-from typing import Any
+from typing import Iterator
 
 import nox
 from nox.sessions import Session
@@ -11,39 +12,104 @@ nox.options.sessions = "lint", "safety", "mypy", "pytype", "tests"
 locations = "src", "tests", "noxfile.py", "docs/conf.py"
 
 
-def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> None:
-    """Install packages constrained by Poetry's lock file.
+class Poetry:
+    """Helper class for invoking Poetry inside a Nox session.
 
-    This function is a wrapper for nox.sessions.Session.install. It
-    invokes pip to install packages inside of the session's virtualenv.
-    Additionally, pip is passed a constraints file generated from
-    Poetry's lock file, to ensure that the packages are pinned to the
-    versions specified in poetry.lock. This allows you to manage the
-    packages as Poetry development dependencies.
-
-    Arguments:
+    Attributes:
         session: The Session object.
-        args: Command-line arguments for pip.
-        kwargs: Additional keyword arguments for Session.install.
-
     """
-    with tempfile.NamedTemporaryFile() as requirements:
-        session.run(
-            "poetry",
-            "export",
-            "--dev",
-            "--format=requirements.txt",
-            f"--output={requirements.name}",
-            external=True,
+
+    def __init__(self, session: Session) -> None:
+        """Constructor."""
+        self.session = session
+
+    @contextlib.contextmanager
+    def export(self, *args: str) -> Iterator[str]:
+        """Export the lock file to requirements format.
+
+        Args:
+            args: Command-line arguments for ``poetry export``.
+
+        Yields:
+            The path to the requirements file.
+        """
+        with tempfile.NamedTemporaryFile() as requirements:
+            self.session.run(
+                "poetry",
+                "export",
+                *args,
+                "--format=requirements.txt",
+                f"--output={requirements.name}",
+                external=True,
+            )
+            yield requirements.name
+
+    def version(self) -> str:
+        """Retrieve the package version.
+
+        Returns:
+            The package version.
+        """
+        output = self.session.run(
+            "poetry", "version", external=True, silent=True, stderr=None
         )
-        session.install(f"--constraint={requirements.name}", *args, **kwargs)
+        return output.split()[1]
+
+    def build(self, *args: str) -> None:
+        """Build the package.
+
+        Args:
+            args: Command-line arguments for ``poetry build``.
+        """
+        self.session.run("poetry", "build", *args, external=True)
+
+
+def install_package(session: Session) -> None:
+    """Build and install the package.
+
+    Build a wheel from the package, and install it into the virtual environment
+    of the specified Nox session.
+
+    The package requirements are installed using the versions specified in
+    Poetry's lock file.
+
+    Args:
+        session: The Session object.
+    """
+    poetry = Poetry(session)
+
+    with poetry.export() as requirements:
+        session.install(f"--requirement={requirements}")
+
+    poetry.build("--format=wheel")
+
+    version = poetry.version()
+    session.install(
+        "--no-deps", "--force-reinstall", f"dist/{package}-{version}-py3-none-any.whl"
+    )
+
+
+def install(session: Session, *args: str) -> None:
+    """Install development dependencies into the session's virtual environment.
+
+    This function is a wrapper for nox.sessions.Session.install.
+
+    The packages must be managed as development dependencies in Poetry.
+
+    Args:
+        session: The Session object.
+        args: Command-line arguments for ``pip install``.
+    """
+    poetry = Poetry(session)
+    with poetry.export("--dev") as requirements:
+        session.install(f"--constraint={requirements}", *args)
 
 
 @nox.session(python="3.8")
 def black(session: Session) -> None:
     """Run black code formatter."""
     args = session.posargs or locations
-    install_with_constraints(session, "black")
+    install(session, "black")
     session.run("black", *args)
 
 
@@ -51,7 +117,7 @@ def black(session: Session) -> None:
 def lint(session: Session) -> None:
     """Lint using flake8."""
     args = session.posargs or locations
-    install_with_constraints(
+    install(
         session,
         "flake8",
         "flake8-annotations",
@@ -68,25 +134,17 @@ def lint(session: Session) -> None:
 @nox.session(python="3.8")
 def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
-    with tempfile.NamedTemporaryFile() as requirements:
-        session.run(
-            "poetry",
-            "export",
-            "--dev",
-            "--format=requirements.txt",
-            "--without-hashes",
-            f"--output={requirements.name}",
-            external=True,
-        )
-        install_with_constraints(session, "safety")
-        session.run("safety", "check", f"--file={requirements.name}", "--bare")
+    poetry = Poetry(session)
+    with poetry.export("--dev", "--without-hashes") as requirements:
+        install(session, "safety")
+        session.run("safety", "check", f"--file={requirements}", "--bare")
 
 
 @nox.session(python=["3.8", "3.7"])
 def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or locations
-    install_with_constraints(session, "mypy")
+    install(session, "mypy")
     session.run("mypy", *args)
 
 
@@ -94,7 +152,7 @@ def mypy(session: Session) -> None:
 def pytype(session: Session) -> None:
     """Type-check using pytype."""
     args = session.posargs or ["--disable=import-error", *locations]
-    install_with_constraints(session, "pytype")
+    install(session, "pytype")
     session.run("pytype", *args)
 
 
@@ -102,16 +160,16 @@ def pytype(session: Session) -> None:
 def tests(session: Session) -> None:
     """Run the test suite."""
     args = session.posargs or ["--cov"]
-    session.run("poetry", "install", "--no-dev", external=True)
-    install_with_constraints(session, "coverage[toml]", "pytest", "pytest-cov")
+    install_package(session)
+    install(session, "coverage[toml]", "pytest", "pytest-cov")
     session.run("pytest", *args)
 
 
 @nox.session(python=["3.8", "3.7"])
 def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
-    session.run("poetry", "install", "--no-dev", external=True)
-    install_with_constraints(session, "pytest", "typeguard")
+    install_package(session)
+    install(session, "pytest", "typeguard")
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 
@@ -119,15 +177,15 @@ def typeguard(session: Session) -> None:
 def xdoctest(session: Session) -> None:
     """Run examples with xdoctest."""
     args = session.posargs or ["all"]
-    session.run("poetry", "install", "--no-dev", external=True)
-    install_with_constraints(session, "xdoctest")
+    install_package(session)
+    install(session, "xdoctest")
     session.run("python", "-m", "xdoctest", package, *args)
 
 
 @nox.session(python="3.8")
 def coverage(session: Session) -> None:
     """Upload coverage data."""
-    install_with_constraints(session, "coverage[toml]", "codecov")
+    install(session, "coverage[toml]", "codecov")
     session.run("coverage", "xml", "--fail-under=0")
     session.run("codecov", *session.posargs)
 
@@ -135,6 +193,6 @@ def coverage(session: Session) -> None:
 @nox.session(python="3.8")
 def docs(session: Session) -> None:
     """Build the documentation."""
-    session.run("poetry", "install", "--no-dev", external=True)
-    install_with_constraints(session, "sphinx", "sphinx-autodoc-typehints")
+    install_package(session)
+    install(session, "sphinx", "sphinx-autodoc-typehints")
     session.run("sphinx-build", "docs", "docs/_build")


### PR DESCRIPTION
Fixes #3 

cjolowicz/cookiecutter-hypermodern-python-instance#6

* Ignore /dist/

* Ignore ANN101 (missing type annotation for self in method)

* Add Poetry helper class for Nox

* Use Poetry.export in install_with_constraints

* Update docstring for install_with_constraints

* Drop kwargs parameter for install_with_constraints

* Rename install_with_constraints to install

* Use Poetry.export in safety session

* Add Poetry.version

* Add Poetry.build

* Add install_package to install wheel into Nox sessions

* Use install_package instead of `poetry install --no-dev`