### PR TITLE
Support running with `python -m <package>`

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -45,6 +45,7 @@ source = ["src", "*/site-packages"]
 [tool.coverage.run]
 branch = true
 source = ["{{cookiecutter.package_name}}"]
+omit = ["*/{{cookiecutter.package_name}}/__main__.py"]
 
 [tool.coverage.report]
 show_missing = true

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__main__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__main__.py
@@ -1,0 +1,5 @@
+"""Main module."""
+from . import console
+
+
+console.main(prog_name="{{cookiecutter.project_name}}")


### PR DESCRIPTION
Fixes #9 

cjolowicz/cookiecutter-hypermodern-python-instance#24

* Allow script invocation via python -m

* Add module docstring

* Disable coverage for __main__