### PR TITLE
Add GitHub Releases link to PyPI and Read the Docs

### DIFF
--- a/{{cookiecutter.project_name}}/docs/index.rst
+++ b/{{cookiecutter.project_name}}/docs/index.rst
@@ -7,6 +7,7 @@
 
    license
    reference
+   Changelog <https://github.com/{{github_user}}/{{cookiecutter.project_name}}/releases>
 
 This package has a command-line interface.
 

--- a/{{cookiecutter.project_name}}/docs/index.rst
+++ b/{{cookiecutter.project_name}}/docs/index.rst
@@ -7,7 +7,7 @@
 
    license
    reference
-   Changelog <https://github.com/{{github_user}}/{{cookiecutter.project_name}}/releases>
+   Changelog <https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/releases>
 
 This package has a command-line interface.
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.pro
 documentation = "https://{{cookiecutter.project_name}}.readthedocs.io"
 
 [tool.poetry.urls]
-Changelog = "https://github.com/{{github_user}}/{{cookiecutter.project_name}}/releases"
+Changelog = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/releases"
 
 [tool.poetry.dependencies]
 python = "^3.7"

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -9,6 +9,9 @@ homepage = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.proje
 repository = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}"
 documentation = "https://{{cookiecutter.project_name}}.readthedocs.io"
 
+[tool.poetry.urls]
+Changelog = "https://github.com/{{github_user}}/{{cookiecutter.project_name}}/releases"
+
 [tool.poetry.dependencies]
 python = "^3.7"
 click = "^7.0"


### PR DESCRIPTION
Fixes #13 

cjolowicz/cookiecutter-hypermodern-python-instance#20

* Link GitHub Releases from Sphinx documentation

* Link GitHub Releases from PyPI page