### PR TITLE
Add flake8-rst-docstrings to linting rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The linter suite uses the following tools and Flake8 plugins:
 - [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) to detect bugs and design problems
 - [flake8-docstrings](https://gitlab.com/pycqa/flake8-docstrings) for integration with pydocstyle
 - [flake8-import-order](https://github.com/PyCQA/flake8-import-order) to check the order of import statements
+- [flake8-rst-docstrings](https://github.com/peterjc/flake8-rst-docstrings) to check that docstrings are valid reStructuredText
 - [mccabe](https://github.com/PyCQA/mccabe) to limit the code complexity
 - [pep8-naming](https://github.com/pycqa/pep8-naming) to enforce naming conventions from [PEP 8](http://www.python.org/dev/peps/pep-0008/)
 - [pycodestyle](https://github.com/pycqa/pycodestyle) to enforce style conventions from [PEP 8](http://www.python.org/dev/peps/pep-0008/)

--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-select = ANN,B,B9,BLK,C,D,DAR,E,F,I,N,S,W
+select = ANN,B,B9,BLK,C,D,DAR,E,F,I,N,RST,S,W
 ignore = ANN101,E203,E501,W503
 max-line-length = 80
 max-complexity = 10

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -127,6 +127,7 @@ def lint(session: Session) -> None:
         "flake8-bugbear",
         "flake8-docstrings",
         "flake8-import-order",
+        "flake8-rst-docstrings",
         "pep8-naming",
         "darglint",
     )

--- a/{{cookiecutter.project_name}}/poetry.lock
+++ b/{{cookiecutter.project_name}}/poetry.lock
@@ -296,6 +296,18 @@ flake8 = "*"
 
 [[package]]
 category = "dev"
+description = "Python docstring reStructuredText (RST) validator"
+name = "flake8-rst-docstrings"
+optional = false
+python-versions = "*"
+version = "0.0.13"
+
+[package.dependencies]
+flake8 = ">=3.0.0"
+restructuredtext_lint = "*"
+
+[[package]]
+category = "dev"
 description = "Git Object Database"
 name = "gitdb"
 optional = false
@@ -681,6 +693,17 @@ socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
 category = "dev"
+description = "reStructuredText linter"
+name = "restructuredtext-lint"
+optional = false
+python-versions = "*"
+version = "1.3.0"
+
+[package.dependencies]
+docutils = ">=0.11,<1.0"
+
+[[package]]
+category = "dev"
 description = "Safety checks your installed dependencies for known security vulnerabilities."
 name = "safety"
 optional = false
@@ -934,7 +957,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "54edd5278eb4b8028c9299bac6c85dc9927687f2ff1471b1da290182f9f9b4ea"
+content-hash = "c16adb9033e83f16aad83673e06a5fd55ff9aa44f6b6949f1bd6672fd08d2f3c"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1068,6 +1091,9 @@ flake8-import-order = [
 flake8-polyfill = [
     {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
     {file = "flake8_polyfill-1.0.2-py2.py3-none-any.whl", hash = "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9"},
+]
+flake8-rst-docstrings = [
+    {file = "flake8-rst-docstrings-0.0.13.tar.gz", hash = "sha256:b1b619d81d879b874533973ac04ee5d823fdbe8c9f3701bfe802bb41813997b4"},
 ]
 gitdb = [
     {file = "gitdb-4.0.2-py3-none-any.whl", hash = "sha256:284a6a4554f954d6e737cddcff946404393e030b76a282c6640df8efd6b3da5e"},
@@ -1208,7 +1234,7 @@ pyflakes = [
     {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
 ]
 pygments = [
-    {file = "Pygments-2.6.1-py2.py3-none-any.whl", hash = "sha256:aa931c0bd5daa25c475afadb2147115134cfe501f0656828cbe7cb566c7123bc"},
+    {file = "Pygments-2.6.1-py3-none-any.whl", hash = "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"},
     {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
 ]
 pyparsing = [
@@ -1273,6 +1299,9 @@ regex = [
 requests = [
     {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
     {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
+]
+restructuredtext-lint = [
+    {file = "restructuredtext_lint-1.3.0.tar.gz", hash = "sha256:97b3da356d5b3a8514d8f1f9098febd8b41463bed6a1d9f126cf0a048b6fd908"},
 ]
 safety = [
     {file = "safety-1.8.7-py2.py3-none-any.whl", hash = "sha256:05f77773bbab834502328b29ed013677aa53ed0c22b6e330aef7d2a7e1dfd838"},

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -39,6 +39,7 @@ sphinx = "^2.3.1"
 sphinx-autodoc-typehints = "^1.10.3"
 recommonmark = "^0.6.0"
 pep8-naming = "^0.9.1"
+flake8-rst-docstrings = "^0.0.13"
 
 [tool.poetry.scripts]
 {{cookiecutter.project_name}} = "{{cookiecutter.package_name}}.console:main"


### PR DESCRIPTION
This PR adds [flake8-rst-docstrings](https://github.com/peterjc/flake8-rst-docstrings) linting rules by

- Adding a dependency to Poetry files
- Adding `RST` validation code to `.flake8`
- Adding flake8-rst-docstrings installation to Nox lint session
- Adding flake8-rst-docstrings description to `README.md`
