### PR TITLE
Remove coverage session

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -751,7 +751,6 @@ The following tables gives an overview of the available Nox sessions:
 Session                                Description                    Python              Default
 ====================================== ============================== ================== =========
 `black <The black session_>`__         Format code with Black_        ``3.8``
-`coverage <The coverage session_>`__   Generate a coverage report     ``3.8``
 `docs <The docs session_>`__           Build Sphinx_ documentation    ``3.8``
 `lint <The lint session_>`__           Lint with Flake8_              ``3.6`` … ``3.8``      ✓
 `mypy <The mypy session_>`__           Type-check with mypy_          ``3.6`` … ``3.8``      ✓
@@ -902,31 +901,6 @@ in the ``tool.coverage`` table.
 The configuration informs the tool about your package name and source tree layout.
 It also enables branch analysis and the display of line numbers for missing coverage,
 and specifies the target coverage percentage.
-
-
-.. _`The coverage session`:
-
-The coverage session
---------------------
-
-.. note::
-
-   This session is intended for use inside Continuous Integration.
-   For a coverage report, simply run the `tests <the tests session_>`__ session.
-
-Run the coverage session like this:
-
-.. code:: console
-
-   $ nox --session=coverage
-
-The coverage session exports the coverage data to `cobertura`__ XML format,
-the format expected by Codecov_.
-
-__ https://cobertura.github.io/cobertura/
-
-This session always runs with the current major release of Python.
-It does not accept additional options.
 
 
 Linting with Flake8
@@ -1805,10 +1779,10 @@ The Coverage workflow uploads coverage data to Codecov_.
 
 The workflow is triggered on every push to the GitHub repository.
 It executes the `tests session <the tests session_>`__
-to collect coverage data,
-and the `coverage session <the coverage session_>`__
-to produce a coverage report in XML format.
+to generate a coverage report in `cobertura`__ XML format.
 This coverage report is then uploaded to Codecov_.
+
+__ https://cobertura.github.io/cobertura/
 
 The workflow uses the following GitHub Actions:
 

--- a/{{cookiecutter.project_name}}/.github/workflows/coverage.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/coverage.yml
@@ -11,6 +11,6 @@ jobs:
           architecture: x64
       - run: pip install nox==2019.11.9
       - run: pip install poetry==1.0.5
-      - run: nox --sessions tests-3.8 coverage
+      - run: nox --sessions tests-3.8 -- --cov --cov-report=xml
       - if: always()
         uses: codecov/codecov-action@v1

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -188,13 +188,6 @@ def xdoctest(session: Session) -> None:
 
 
 @nox.session(python="3.8")
-def coverage(session: Session) -> None:
-    """Upload coverage data."""
-    install(session, "coverage[toml]")
-    session.run("coverage", "xml", "--fail-under=0")
-
-
-@nox.session(python="3.8")
 def docs(session: Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]


### PR DESCRIPTION
There is no longer any need for the coverage session, now that we upload to Codecov using their GitHub Action.

The coverage session was still used to generate an XML coverage report. Instead, the Coverage workflow now passes `--cov-report=xml` to the tests session.

cjolowicz/cookiecutter-hypermodern-python-instance#94
