### PR TITLE
Disable codecov comments

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -2023,11 +2023,6 @@ Open a pull request for your branch on GitHub:
 
 Release notes are pre-filled with the titles of merged pull requests.
 
-Opening the pull request triggers another automated step:
-
-- Codecov_ comments on the pull request,
-  summarizing how the changes impact code coverage.
-
 
 How to accept a pull request
 ----------------------------

--- a/{{cookiecutter.project_name}}/codecov.yml
+++ b/{{cookiecutter.project_name}}/codecov.yml
@@ -1,3 +1,4 @@
+comment: false
 coverage:
   status:
     project:


### PR DESCRIPTION
Users can always click the failed coverage check.