### PR TITLE
Fix CI cache for pre-commit workflow

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/pre-commit.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/pre-commit.yml
@@ -15,13 +15,13 @@ jobs:
       - name: set PYTHON_VERSION_HASH
         run: |
           echo "::set-env name=PYTHON_VERSION_HASH::$(python -c '
-            import hashlib
-            import sys
+          import hashlib
+          import sys
 
-            payload = sys.version.encode() + sys.executable.encode()
-            digest = hashlib.sha256(payload).hexdigest()
+          payload = sys.version.encode() + sys.executable.encode()
+          digest = hashlib.sha256(payload).hexdigest()
 
-            print(digest)
+          print(digest)
           ')"
       - uses: actions/cache@v1
         with:


### PR DESCRIPTION
The cache key for the pre-commit workflow did not include the Python version,
due to an `IndentationError` in the Python code used to generate the key.