### PR TITLE
Use Dependabot's `dependencies` label for Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,8 +19,10 @@ categories:
     label: "refactoring"
   - title: ":lipstick: Style"
     label: "style"
-  - title: ":package: Build System"
-    label: "build"
+  - title: ":package: Dependencies"
+    labels:
+      - "dependencies"
+      - "build"
 template: |
   ## Changes
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Use labels to group the pull requests into sections:
 | --------------- | -------------------------------------------- |
 | `breaking`      | :boom: Breaking Changes                      |
 | `bug`           | :beetle: Fixes                               |
-| `build`         | :package: Build System and Dependencies      |
+| `dependencies`  | :package: Dependencies                       |
 | `ci`            | :construction_worker: Continuous Integration |
 | `documentation` | :books: Documentation                        |
 | `enhancement`   | :rocket: Features                            |

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1850,7 +1850,7 @@ Label               Section
 ``documentation``   📚 Documentation
 ``refactoring``     🔨 Refactoring
 ``style``           💄 Style
-``build``           📦 Build System and Dependencies
+``dependencies``    📦 Dependencies
 =================== ================================
 
 .. table-release-drafter-sections-end

--- a/{{cookiecutter.project_name}}/.github/release-drafter.yml
+++ b/{{cookiecutter.project_name}}/.github/release-drafter.yml
@@ -19,8 +19,8 @@ categories:
     label: "refactoring"
   - title: ":lipstick: Style"
     label: "style"
-  - title: ":package: Build System"
-    label: "build"
+  - title: ":package: Dependencies"
+    label: "dependencies"
 template: |
   ## Changes
 

--- a/{{cookiecutter.project_name}}/.github/release-drafter.yml
+++ b/{{cookiecutter.project_name}}/.github/release-drafter.yml
@@ -20,7 +20,9 @@ categories:
   - title: ":lipstick: Style"
     label: "style"
   - title: ":package: Dependencies"
-    label: "dependencies"
+    labels:
+      - "dependencies"
+      - "build"
 template: |
   ## Changes
 


### PR DESCRIPTION
The `build` label is kept for backwards compatibility. It should be removed from the Release Drafter configuration eventually.