### PR TITLE
Strip PR reference in Reset Instance workflow

### DIFF
--- a/.github/workflows/reset-instance.yml
+++ b/.github/workflows/reset-instance.yml
@@ -41,7 +41,7 @@ jobs:
           cd cookiecutter-hypermodern-python
           author="$(git show --no-patch --format='%an <%ae>')"
           date="$(git show --no-patch --format=%ad)"
-          message="$(git show --no-patch --format=%B)
+          message="$(git show --no-patch --format=%B | sed 's/ *(#[0-9]\+)//g')
 
           Original-Commit: ${GITHUB_REPOSITORY}@${GITHUB_SHA::7}"
 


### PR DESCRIPTION
These references are misleading in the instance, as they are linked
to the instance repository instead of the cookiecutter repository, where
the PR was created.