### PR TITLE
Convert Code of Conduct to reStructuredText

### DIFF
--- a/{{cookiecutter.project_name}}/CODE_OF_CONDUCT.rst
+++ b/{{cookiecutter.project_name}}/CODE_OF_CONDUCT.rst
@@ -1,12 +1,16 @@
-# Contributor Covenant Code of Conduct
+Contributor Covenant Code of Conduct
+====================================
 
-## Our Pledge
+Our Pledge
+----------
 
 We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
-## Our Standards
+
+Our Standards
+-------------
 
 Examples of behavior that contributes to a positive environment for our community include:
 
@@ -27,58 +31,75 @@ Examples of unacceptable behavior include:
 - Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-## Enforcement Responsibilities
+Enforcement Responsibilities
+----------------------------
 
 Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
 Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
-## Scope
+
+Scope
+-----
 
 This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
-## Enforcement
+
+Enforcement
+-----------
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at {{cookiecutter.email}}. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
-## Enforcement Guidelines
+
+Enforcement Guidelines
+----------------------
 
 Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
-### 1. Correction
+
+1. Correction
+~~~~~~~~~~~~~
 
 **Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
 **Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
-### 2. Warning
+
+2. Warning
+~~~~~~~~~~
 
 **Community Impact**: A violation through a single incident or series of actions.
 
 **Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
-### 3. Temporary Ban
+
+3. Temporary Ban
+~~~~~~~~~~~~~~~~
 
 **Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
 **Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
-### 4. Permanent Ban
+
+4. Permanent Ban
+~~~~~~~~~~~~~~~~
 
 **Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within the community.
 
-## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
+Attribution
+-----------
+
+This Code of Conduct is adapted from the `Contributor Covenant <homepage_>`__, version 2.0,
 available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by `Mozilla’s code of conduct enforcement ladder <https://github.com/mozilla/diversity>`__.
 
-[homepage]: https://www.contributor-covenant.org
+.. _homepage: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/{{cookiecutter.project_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.project_name}}/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Here is a list of important resources for contributors:
 [source code]: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}
 [documentation]: https://{{cookiecutter.project_name}}.readthedocs.io/
 [issue tracker]: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/issues
-[code of conduct]: CODE_OF_CONDUCT.md
+[code of conduct]: https://{{cookiecutter.project_name}}.readthedocs.io/codeofconduct.html
 
 ## How to report a bug
 

--- a/{{cookiecutter.project_name}}/docs/CODE_OF_CONDUCT.md
+++ b/{{cookiecutter.project_name}}/docs/CODE_OF_CONDUCT.md
@@ -1,1 +1,0 @@
-../CODE_OF_CONDUCT.md

--- a/{{cookiecutter.project_name}}/docs/codeofconduct.rst
+++ b/{{cookiecutter.project_name}}/docs/codeofconduct.rst
@@ -1,0 +1,1 @@
+.. include:: ../CODE_OF_CONDUCT.rst

--- a/{{cookiecutter.project_name}}/docs/index.rst
+++ b/{{cookiecutter.project_name}}/docs/index.rst
@@ -7,7 +7,7 @@
 
    reference
    CONTRIBUTING
-   Code of Conduct <CODE_OF_CONDUCT>
+   Code of Conduct <codeofconduct>
    license
    Changelog <https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/releases>
 


### PR DESCRIPTION
* Generate CODE_OF_CONDUCT.rst using Pandoc

* Clean up generated markup in CODE_OF_CONDUCT.rst

* Add docs/codeofconduct.rst wrapper

* Use docs/codeofconduct.rst in master toctree

* Remove docs/CODE_OF_CONDUCT.md

* Remove CODE_OF_CONDUCT.md

* Adapt CoC link in Contributor Guide

cjolowicz/cookiecutter-hypermodern-python-instance#99