### PR TITLE
Configure mypy to be strict and pretty

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,8 @@ from datetime import datetime
 project = "Hypermodern Python Cookiecutter"
 author = "Claudio Jolowicz"
 copyright = f"{datetime.now().year}, {author}"
+extensions = ["sphinx.ext.intersphinx"]
+intersphinx_mapping = {"mypy": ("https://mypy.readthedocs.io/en/stable/", None)}
 html_static_path = ["_static"]
 html_theme = "alabaster"
 html_theme_options = {

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1461,13 +1461,42 @@ For example, the following command type-checks only the ``console`` module:
 
    $ nox --session=mypy -- src/<package>/console.py
 
+
+Configuring mypy
+----------------
+
 Configure mypy using the `mypy.ini`__ configuration file.
 
 __ https://mypy.readthedocs.io/en/stable/config_file.html
 
-The *Hypermodern Python Cookiecutter* disables import errors
-for some packages for which type definitions are not yet available,
-using the ``ignore_missing_imports`` option.
+The *Hypermodern Python Cookiecutter* enables the strictness options
+(the options enabled by the :option:`--strict <mypy --strict>` flag):
+
+- :option:`check_untyped_defs <mypy --check-untyped-defs>`
+- :option:`disallow_any_generics <mypy --disallow-any-generics>`
+- :option:`disallow_incomplete_defs <mypy --disallow-incomplete-defs>`
+- :option:`disallow_subclassing_any <mypy --disallow-subclassing-any>`
+- :option:`disallow_untyped_calls <mypy --disallow-untyped-calls>`
+- :option:`disallow_untyped_decorators <mypy --disallow-untyped-decorators>`
+- :option:`disallow_untyped_defs <mypy --disallow-untyped-defs>`
+- [*no*] :option:`implicit_reexport <mypy --no-implicit-reexport>`
+- :option:`no_implicit_optional <mypy --no-implicit-optional>`
+- :option:`strict_equality <mypy --strict-equality>`
+- :option:`warn_redundant_casts <mypy --warn-redundant-casts>`
+- :option:`warn_return_any <mypy --warn-return-any>`
+- :option:`warn_unused_configs <mypy --warn-unused-configs>`
+- :option:`warn_unused_ignores <mypy --warn-unused-ignores>`
+
+The :option:`ignore_missing_imports <mypy --ignore-missing-imports>` option
+is used to disable import errors for selected packages
+where type information is not yet available.
+
+The following options are enabled for enhanced output:
+
+- :option:`pretty <mypy --pretty>`
+- :option:`show_column_numbers <mypy --show-column-numbers>`
+- :option:`show_error_codes <mypy --show-error-codes>`
+- :option:`show_error_context <mypy --show-error-context>`
 
 
 .. _`The pytype session`:

--- a/{{cookiecutter.project_name}}/mypy.ini
+++ b/{{cookiecutter.project_name}}/mypy.ini
@@ -1,4 +1,35 @@
 [mypy]
+check_untyped_defs = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+implicit_reexport = False
+no_implicit_optional = True
+pretty = True
+show_column_numbers = True
+show_error_codes = True
+show_error_context = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+warn_unused_configs = True
+warn_unused_ignores = True
 
-[mypy-nox.*,pytest]
+[mypy-noxfile]
+disallow_untyped_decorators = False
+
+[mypy-tests.*]
+disallow_untyped_decorators = False
+
+[mypy-importlib_metadata]
+ignore_missing_imports = True
+
+[mypy-nox.*]
+ignore_missing_imports = True
+
+[mypy-pytest]
 ignore_missing_imports = True

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -3,7 +3,7 @@ import contextlib
 from pathlib import Path
 import shutil
 import tempfile
-from typing import Iterator
+from typing import cast, Iterator
 
 import nox
 from nox.sessions import Session
@@ -56,7 +56,7 @@ class Poetry:
         output = self.session.run(
             "poetry", "version", external=True, silent=True, stderr=None
         )
-        return output.split()[1]
+        return cast(str, output).split()[1]
 
     def build(self, *args: str) -> None:
         """Build the package.

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -1,8 +1,10 @@
 """{{cookiecutter.friendly_name}}."""
-try:
-    from importlib.metadata import version, PackageNotFoundError  # type: ignore
-except ImportError:  # pragma: no cover
-    from importlib_metadata import version, PackageNotFoundError  # type: ignore
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    from importlib.metadata import version, PackageNotFoundError  # pragma: no cover
+else:
+    from importlib_metadata import version, PackageNotFoundError  # pragma: no cover
 
 
 try:


### PR DESCRIPTION
Enable the strictness options associated with the `--strict` flag:

  --warn-unused-configs
  --disallow-any-generics
  --disallow-subclassing-any
  --disallow-untyped-calls
  --disallow-untyped-defs
  --disallow-incomplete-defs
  --check-untyped-defs
  --disallow-untyped-decorators
  --no-implicit-optional
  --warn-redundant-casts
  --warn-unused-ignores
  --warn-return-any
  --no-implicit-reexport
  --strict-equality

Also enable options for enhanced output:

  --show-error-codes
  --show-error-context
  --show-column-numbers
  --pretty

Fix some issues in the code base due to the increased strictness:

  - Use `sys.version_info` instead of `try...except ImportError`
  - Ignore missing imports for `importlib_metadata`.
  - Allow untyped decorators in Nox sessions and test suite.
  - Fix `[no-any-return]` in `Poetry.version`.

Closes #17 

--

cjolowicz/cookiecutter-hypermodern-python-instance#104

* Split ignore_missing_imports into separate sections

* Enable warn_unused_configs

  This flag makes mypy warn about unused ``[mypy-<pattern>]`` config file
  sections.

  Warns about per-module sections in the config file that do not match any files
  processed when invoking mypy.

  (This requires turning off incremental mode using ``incremental = False``.)

* Enable disallow_any_generics

  Disallows usage of generic types that do not specify explicit type parameters.

  This flag disallows usage of generic types that do not specify explicit type
  parameters. Moreover, built-in collections (such as :py:class:`list` and
  :py:class:`dict`) become disallowed as you should use their aliases from the
  :py:mod:`typing` module (such as :py:class:`List[int] <typing.List>` and
  :py:class:`Dict[str, str] <typing.Dict>`).

* Enable disallow_subclassing_any

  Disallows subclassing a value of type ``Any``.

  This flag reports an error whenever a class subclasses a value of type
  ``Any``. This may occur when the base class is imported from a module that
  doesn't exist (when using :option:`--ignore-missing-imports`) or is ignored
  due to :option:`--follow-imports=skip <--follow-imports>` or a ``# type:
  ignore`` comment on the ``import`` statement.

  Since the module is silenced, the imported class is given a type of ``Any``.
  By default mypy will assume that the subclass correctly inherited the base
  class even though that may not actually be the case. This flag makes mypy
  raise an error instead.

* Enable disallow_untyped_calls

  Disallows calling functions without type annotations from functions with type
  annotations.

  This flag reports an error whenever a function with type annotations calls a
  function defined without annotations.

* Enable disallow_untyped_defs

  This flag reports an error whenever it encounters a function definition
  without type annotations.

  Disallows defining functions without type annotations or with incomplete type
  annotations.

* Enable disallow_incomplete_defs

  This flag reports an error whenever it encounters a partly annotated function
  definition.

  Disallows defining functions with incomplete type annotations.

* Enable check_untyped_defs

  Type-checks the interior of functions without type annotations.

  This flag is less severe than the previous two options -- it type checks the
  body of every function, regardless of whether it has type annotations. (By
  default the bodies of functions without annotations are not type checked.)

  It will assume all arguments have type ``Any`` and always infer ``Any`` as the
  return type.

* Enable disallow_untyped_decorators

  Reports an error whenever a function with type annotations is decorated with a
  decorator without annotations.

  This flag reports an error whenever a function with type annotations is
  decorated with a decorator without annotations.

* Enable no_implicit_optional

  Changes the treatment of arguments with a default value of ``None`` by not
  implicitly making their type :py:data:`~typing.Optional`.

  This flag causes mypy to stop treating arguments with a ``None`` default value
  as having an implicit :py:data:`~typing.Optional` type.

* Enable warn_redundant_casts

  Warns about casting an expression to its inferred type.

  This flag will make mypy report an error whenever your code uses an
  unnecessary cast that can safely be removed.

* Enable warn_unused_ignores

  Warns about unneeded ``# type: ignore`` comments.

  This flag will make mypy report an error whenever your code uses a ``# type:
  ignore`` comment on a line that is not actually generating an error message.

  This flag, along with the :option:`--warn-redundant-casts` flag, are both
  particularly useful when you are upgrading mypy. Previously, you may have
  needed to add casts or ``# type: ignore`` annotations to work around bugs in
  mypy or missing stubs for 3rd party libraries.

  These two flags let you discover cases where either workarounds are no longer
  necessary.

* Enable warn_return_any

  Shows a warning when returning a value with type ``Any`` from a function
  declared with a non-``Any`` return type.

  This flag causes mypy to generate a warning when returning a value with type
  ``Any`` from a function declared with a non-``Any`` return type.

* Enable warn_unreachable

  Shows a warning when encountering any code inferred to be unreachable or
  redundant after performing type analysis.

  This flag will make mypy report an error whenever it encounters code
  determined to be unreachable or redundant after performing type analysis. This
  can be a helpful way of detecting certain kinds of bugs in your code.

  To help prevent mypy from generating spurious warnings, the "Statement is
  unreachable" warning will be silenced in exactly two cases:

  1. When the unreachable statement is a ``raise`` statement, is an
     ``assert False`` statement, or calls a function that has the
     :py:data:`~typing.NoReturn` return type hint. In other words,
     when the unreachable statement throws an error or terminates
     the program in some way.

  2. When the unreachable statement was *intentionally* marked as unreachable
     using :ref:`version_and_platform_checks`.

  Mypy currently cannot detect and report unreachable or redundant code inside
  any functions using :ref:`type-variable-value-restriction`.

  This limitation will be removed in future releases of mypy.

* Disable implicit_reexport

  By default, imported values to a module are treated as exported and mypy
  allows other modules to import them. When false, mypy will not re-export
  unless the item is imported using from-as or is included in ``__all__``. Note
  that mypy treats stub files as if this is always disabled.

  By default, imported values to a module are treated as exported and mypy
  allows other modules to import them. This flag changes the behavior to not
  re-export unless the item is imported using from-as or is included in
  ``__all__``. Note this is always treated as enabled for stub files.

* Enable strict_equality

  Prohibit equality checks, identity checks, and container checks between
  non-overlapping types.

  By default, mypy allows always-false comparisons like ``42 == 'no'``. Use this
  flag to prohibit such comparisons of non-overlapping types, and similar
  identity and container checks.

* Enable show_error_context

  Prefixes each error with the relevant context.

  This flag will precede all errors with "note" messages explaining the context
  of the error.

* Enable show_column_numbers

  Shows column numbers in error messages.

  This flag will add column offsets to error messages. Column offsets are
  0-based.

* Enable show_error_codes

  Shows error codes in error messages.

  This flag will add an error code ``[<code>]`` to error messages. The error
  code is shown after each error message.

  See :ref:`error-codes` for more information.

* Enable pretty

  Use visually nicer output in error messages: use soft word wrap, show source
  code snippets, and show error location markers.

* Allow untyped decorators in noxfile.py

  The @nox.session decorator is untyped, because mypy cannot import type
  information for nox. This leads to errors like the following:

    noxfile.py: note: At top level:
    noxfile.py:111:2: error: Untyped decorator makes function "black" untyped  [misc]
        @nox.session(python="3.8")
        ^

* Allow untyped decorators in tests

  The @pytest.fixture decorator is untyped, because mypy cannot import type
  information for pytest. This leads to the following error:

    tests/test_console.py:8:2: error: Untyped decorator makes function "runner" untyped  [misc]
        @pytest.fixture
        ^

* Use sys.version_info instead of try...except ImportError

  Importing under try...except forces us to apply a `type: ignore` comment to
  the try branch for Python versions without the module. This comment, in turn,
  leads to an error in strict mode, for the Python version having the module:

    src/cookiecutter_hypermodern_python_instance/__init__.py:3: error: unused 'type: ignore' comment
            from importlib.metadata import version, PackageNotFoundError  # type: ignore
            ^

* Enable ignore_missing_imports for importlib_metadata

* Do not return Any from Poetry.version

  The return type of nox.sessions.Session.run is Any, because mypy cannot find
  type information for nox. Use a cast to tell mypy that the function actually
  returns a str. (This is the case when `silent` is passed.)