### PR TITLE
Add pre-commit hook for mypy

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1491,6 +1491,11 @@ The :option:`ignore_missing_imports <mypy --ignore-missing-imports>` option
 is used to disable import errors for selected packages
 where type information is not yet available.
 
+The :ref:`mypy_path <mypy:config-file-import-discovery>` option is set to the
+``src`` directory. This is required to avoid errors about missing imports
+related to your own package when mypy is invoked on files located outside of it,
+such as modules in the test suite.
+
 The following options are enabled for enhanced output:
 
 - :option:`pretty <mypy --pretty>`

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1337,7 +1337,7 @@ Available hooks
 ---------------
 
 The *Hypermodern Python Cookiecutter* comes with
-a minimal pre-commit configuration,
+a pre-commit configuration
 consisting of the following hooks:
 
 __ https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
@@ -1347,6 +1347,7 @@ Hook                     Description
 ======================== ===============================================
 `black <Black_>`__       Run the Black_ code formatter
 `flake8 <Flake8_>`__     Run the Flake8_ linter
+`mypy <mypy_>`__         Run the mypy_ static type checker
 `prettier <Prettier_>`__ Run the Prettier_ code formatter
 check-yaml_              Validate YAML_ files
 end-of-file-fixer_       Ensure files are terminated by a single newline
@@ -1357,9 +1358,14 @@ trailing-whitespace_     Ensure lines do not contain trailing whitespace
 .. _`end-of-file-fixer`: https://github.com/pre-commit/pre-commit-hooks#end-of-file-fixer
 .. _`trailing-whitespace`: https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace
 
-Black_ and Flake8_ are managed as development dependencies by Poetry.
-Therefore, their hooks are run in the Poetry environment,
-rather than in pre-commit environments.
+Black_, Flake8_, and mypy_ are run via Poetry using a `repository-local hook`_.
+This allows you to manage these tools as development dependencies in Poetry,
+rather than having duplicate and potentially diverging version pins in the pre-commit configuration.
+This does require you, however, to run `poetry install`_
+before you can use pre-commit with your project.
+
+.. _`repository-local hook`: https://pre-commit.com/#repository-local-hooks
+
 These checks run somewhat faster than the corresponding Nox sessions,
 for several reasons:
 

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -21,3 +21,9 @@ repos:
         entry: poetry run flake8
         language: system
         types: [python]
+      - id: mypy
+        name: mypy
+        entry: poetry run mypy
+        language: system
+        types: [python]
+        require_serial: true

--- a/{{cookiecutter.project_name}}/mypy.ini
+++ b/{{cookiecutter.project_name}}/mypy.ini
@@ -7,6 +7,7 @@ disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
 implicit_reexport = False
+mypy_path = src
 no_implicit_optional = True
 pretty = True
 show_column_numbers = True


### PR DESCRIPTION
This adds support for running mypy via pre-commit.

Closes #57 

Like flake8 and black, mypy is run via Poetry using a [local hook]. This has the drawback that you need to run `poetry install` before you can use pre-commit with your project. On other hand, it allows you to manage these tools as development dependencies in Poetry. The alternative would be to have duplicate and potentially diverging version pins in the Poetry lock file and the pre-commit configuration. Also, pinning subdependencies does not appear to be very practical with pre-commit.

[local hook]: https://pre-commit.com/#repository-local-hooks

Set [mypy_path] in the configuration file pointing it to the `src` directory. This is required to avoid errors about missing imports related to your package when mypy is invoked on files located outside of the package, such as modules in the test suite. For example, pre-commit runs mypy on staged files only, so this would be a common issue with our mypy pre-commit hook.

This solution is preferred to passing `MYPYPATH` via the pre-commit hook, for two reasons:

- It is more portable because it does not require `env(1)` to be available.
- It will benefit uses of mypy outside of the pre-commit framework.

Here is an example of an error message resulting from running mypy on a test module without mypy_path:

```
tests/test_console.py:5:1: error: Skipping analyzing 'cookiecutter_hypermodern_python_instance': found module but no type hints or library stubs  [import]
    from cookiecutter_hypermodern_python_instance import console
    ^
tests/test_console.py:5:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
```

[mypy_path]: https://mypy.readthedocs.io/en/stable/config_file.html#config-file-import-discovery

The [require_serial] option is enabled like in pre-commit's own mypy mirror. The rationale for this appears to be performance, see https://github.com/pre-commit/mirrors-mypy/issues/2.

[require_serial]: https://pre-commit.com/#creating-new-hooks