### PR TITLE
Remove flake8-annotations

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -973,7 +973,6 @@ flake8-rst-docstrings_  Find invalid reStructuredText_ in docstrings            
 flake8-black_           Enforce the Black_ code style                                  `BLK <flake8-black codes_>`__
 flake8-bugbear_         Detect bugs and design problems                                `B <flake8-bugbear codes_>`__
 mccabe_                 Limit the code complexity                                      `C <mccabe codes_>`__
-flake8-annotations_     Enforce type coverage                                          `ANN <flake8-annotations codes_>`__
 darglint_               Detect inaccurate docstrings                                   `DAR <darglint codes_>`__
 flake8-bandit_          Detect common security issues, via Bandit_                     `S <Bandit codes_>`__
 ======================= ============================================================== =========
@@ -1176,22 +1175,6 @@ The *Hypermodern Python Cookiecutter*
 limits code complexity to a value of 10.
 
 .. _`Cyclomatic complexity`: https://en.wikipedia.org/wiki/Cyclomatic_complexity
-
-
-flake8-annotations
-..................
-
-flake8-annotations_ detects the absence of type annotations for functions,
-helping you keep track of unannotated code.
-`Error codes`__ are prefixed by ``ANN`` for "annotation".
-
-The *Hypermodern Python Cookiecutter*
-disables the warning ``ANN101``
-(missing type annotation for ``self`` in method),
-because annotating ``self`` is normally not required.
-
-.. _`flake8-annotations codes`:
-__ https://github.com/python-discord/flake8-annotations#table-of-warnings
 
 
 darglint
@@ -2342,7 +2325,6 @@ __ https://cjolowicz.github.io/posts/hypermodern-python-01-setup/
 .. _`bash`: https://www.gnu.org/software/bash/
 .. _`curl`: https://curl.haxx.se
 .. _`darglint`: https://github.com/terrencepreilly/darglint
-.. _`flake8-annotations`: https://github.com/python-discord/flake8-annotations
 .. _`flake8-bandit`: https://github.com/tylerwince/flake8-bandit
 .. _`flake8-black`: https://github.com/peterjc/flake8-black
 .. _`flake8-bugbear`: https://github.com/PyCQA/flake8-bugbear

--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -1,6 +1,6 @@
 [flake8]
-select = ANN,B,B9,BLK,C,D,DAR,E,F,I,N,RST,S,W
-ignore = ANN101,E203,E501,W503
+select = B,B9,BLK,C,D,DAR,E,F,I,N,RST,S,W
+ignore = E203,E501,W503
 max-line-length = 80
 max-complexity = 10
 application-import-names = {{cookiecutter.package_name}},tests

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -123,7 +123,6 @@ def lint(session: Session) -> None:
     install(
         session,
         "flake8",
-        "flake8-annotations",
         "flake8-bandit",
         "flake8-black",
         "flake8-bugbear",

--- a/{{cookiecutter.project_name}}/poetry.lock
+++ b/{{cookiecutter.project_name}}/poetry.lock
@@ -118,7 +118,7 @@ version = "7.1.1"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "platform_system == \"Windows\" or sys_platform == \"win32\""
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -219,21 +219,6 @@ entrypoints = ">=0.3.0,<0.4.0"
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.5.0,<2.6.0"
 pyflakes = ">=2.1.0,<2.2.0"
-
-[[package]]
-category = "dev"
-description = "Flake8 Type Annotation Checks"
-name = "flake8-annotations"
-optional = false
-python-versions = ">=3.6,<4.0"
-version = "2.0.1"
-
-[package.dependencies]
-flake8 = ">=3.7.9,<4.0.0"
-
-[package.dependencies.typed-ast]
-python = "<3.8"
-version = ">=1.4,<2.0"
 
 [[package]]
 category = "dev"
@@ -1096,7 +1081,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "251257273c067b905bff27873e2284ec8d34700ae4b03c5692e32f28b7aebfe6"
+content-hash = "0b2b4ab47adff8083caa823eeed127c90b0f50d198d7dc93f0095189a65238cb"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1212,10 +1197,6 @@ flake8 = [
     {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
     {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
 ]
-flake8-annotations = [
-    {file = "flake8-annotations-2.0.1.tar.gz", hash = "sha256:a38b44d01abd480586a92a02a2b0a36231ec42dcc5e114de78fa5db016d8d3f9"},
-    {file = "flake8_annotations-2.0.1-py3-none-any.whl", hash = "sha256:d5b0e8704e4e7728b352fa1464e23539ff2341ba11cc153b536fa2cf921ee659"},
-]
 flake8-bandit = [
     {file = "flake8_bandit-2.1.2.tar.gz", hash = "sha256:687fc8da2e4a239b206af2e54a90093572a60d0954f3054e23690739b0b0de3b"},
 ]
@@ -1304,11 +1285,6 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 mccabe = [
@@ -1404,7 +1380,7 @@ pyflakes = [
     {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
 ]
 pygments = [
-    {file = "Pygments-2.6.1-py3-none-any.whl", hash = "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"},
+    {file = "Pygments-2.6.1-py2.py3-none-any.whl", hash = "sha256:aa931c0bd5daa25c475afadb2147115134cfe501f0656828cbe7cb566c7123bc"},
     {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
 ]
 pyparsing = [

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -30,7 +30,6 @@ flake8-bandit = "^2.1.2"
 safety = "^1.8.5"
 mypy = "^0.770"
 pytype = {version = "^2020.4.1", python = ">=3.6,<3.8"}
-flake8-annotations = "^2.0.0"
 typeguard = "^2.7.1"
 flake8-docstrings = "^1.5.0"
 darglint = "^1.2.2"


### PR DESCRIPTION
Closes #51 

mypy is now configured with `disallow_untyped_defs`, so this extension appears to be not needed anymore.