### PR TITLE
Add py.typed marker file (PEP 561)

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1480,11 +1480,6 @@ The :option:`ignore_missing_imports <mypy --ignore-missing-imports>` option
 is used to disable import errors for selected packages
 where type information is not yet available.
 
-The :ref:`mypy_path <mypy:config-file-import-discovery>` option is set to the
-``src`` directory. This is required to avoid errors about missing imports
-related to your own package when mypy is invoked on files located outside of it,
-such as modules in the test suite.
-
 The following options are enabled for enhanced output:
 
 - :option:`pretty <mypy --pretty>`

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -273,7 +273,8 @@ under the ``src`` directory::
   └── <package>
       ├── __init__.py
       ├── __main__.py
-      └── console.py
+      ├── console.py
+      └── py.typed
 
 The ``__init__.py`` file declares the directory as a `Python package`_.
 It also defines a ``__version__`` attribute,
@@ -301,6 +302,13 @@ by specifying a Python interpreter and the package name:
 .. code:: console
 
    $ python -m <package> [<options>]
+
+The ``py.typed`` file is an empty marker file,
+which declares that your package supports typing,
+and is distributed with its own type information
+(see `PEP 561`_).
+This allows people using your package
+to type-check their Python code against it.
 
 
 Uploading to GitHub
@@ -2304,6 +2312,7 @@ __ https://cjolowicz.github.io/posts/hypermodern-python-01-setup/
 .. _`PEP 440`: https://www.python.org/dev/peps/pep-0440/
 .. _`PEP 517`: https://www.python.org/dev/peps/pep-0517/
 .. _`PEP 518`: https://www.python.org/dev/peps/pep-0518/
+.. _`PEP 561`: https://www.python.org/dev/peps/pep-0561/
 .. _`PEP 8`: http://www.python.org/dev/peps/pep-0008/
 .. _`Poetry`: https://python-poetry.org/
 .. _`Prettier`: https://prettier.io/

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -276,40 +276,44 @@ under the ``src`` directory::
       ├── console.py
       └── py.typed
 
-The ``__init__.py`` file declares the directory as a `Python package`_.
-It also defines a ``__version__`` attribute,
-containing the version of your package.
-The version is determined using the installed package metadata,
-by means of the standard `importlib.metadata`_ library.
+``__init__.py``
+   This file declares the directory as a `Python package`_.
+   It also defines a ``__version__`` attribute,
+   containing the version of your package.
+   The version is determined using the installed package metadata,
+   by means of the standard `importlib.metadata`_ library.
 
-.. _`Python package`: https://docs.python.org/3/tutorial/modules.html#packages
-.. _`importlib.metadata`: https://docs.python.org/3/library/importlib.metadata.html
+   .. _`Python package`: https://docs.python.org/3/tutorial/modules.html#packages
+   .. _`importlib.metadata`: https://docs.python.org/3/library/importlib.metadata.html
 
-The ``console.py`` module defines the ``console.main`` entry point
-for the command-line interface.
-The command-line interface is implemented using Click_,
-and supports ``--help`` and ``--version`` options.
-When the package is installed,
-a script named ``<project>`` is placed
-in the ``bin`` directory of the Python installation or virtual environment,
-allowing you to invoke the command-line interface
-like any other console application.
+``console.py``
+   This module defines the ``console.main`` entry point
+   for the command-line interface.
+   The command-line interface is implemented using Click_,
+   and supports ``--help`` and ``--version`` options.
+   When the package is installed,
+   a script named ``<project>`` is placed
+   in the ``bin`` directory of the Python installation or virtual environment,
+   allowing you to invoke the command-line interface
+   like any other console application.
 
-The ``__main__.py`` module allows you to
-invoke the command-line interface
-by specifying a Python interpreter and the package name:
+``__main__.py``
+   This module allows you to
+   invoke the command-line interface
+   by specifying a Python interpreter and the package name:
 
-.. code:: console
+   .. code:: console
 
-   $ python -m <package> [<options>]
+      $ python -m <package> [<options>]
 
-The ``py.typed`` file is an empty marker file,
-which declares that your package supports typing,
-and is distributed with its own type information
-(see `PEP 561`_).
-This allows people using your package
-to type-check their Python code against it.
-
+``py.typed``
+   This is an empty marker file,
+   which declares that your package supports typing
+   and is distributed with its own type information
+   (`PEP 561`_).
+   This allows people using your package
+   to type-check their Python code against it.
+ 
 
 Uploading to GitHub
 -------------------

--- a/{{cookiecutter.project_name}}/mypy.ini
+++ b/{{cookiecutter.project_name}}/mypy.ini
@@ -6,7 +6,6 @@ disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
-mypy_path = src
 no_implicit_optional = True
 no_implicit_reexport = True
 pretty = True

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -148,6 +148,7 @@ def safety(session: Session) -> None:
 def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or locations
+    install_package(session)
     install(session, "mypy")
     session.run("mypy", *args)
 


### PR DESCRIPTION
Distribute inline type information using the `py.typed` marker file ([PEP 561]).

[pep 561]: https://www.python.org/dev/peps/pep-0561/

This allows us to remove `mypy_path` from mypy.ini.

Install the package into the Nox session for mypy. This is required to allow type-checking the test suite (when not also type-checking the package itself).

* Add py.typed marker file (PEP 561)

* Remove mypy_path from mypy.ini

This is no longer needed because the installed package contains the py.typed
marker file (PEP 561), allowing mypy to access inline type information. If an
import is followed from a module located outside of the package, mypy no longer
needs MYPY_PATH to be able to extract type information from the package. The
only requirement is that our package must be installed into the environment mypy
is running it, for example the Nox session or the Poetry environment.

* Install the package into the Nox session for mypy

cjolowicz/cookiecutter-hypermodern-python-instance#108
