### PR TITLE
Remove __version__ and importlib_metadata

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -255,13 +255,8 @@ under the ``src`` directory::
 
 ``__init__.py``
    This file declares the directory as a `Python package`_.
-   It also defines a ``__version__`` attribute,
-   containing the version of your package.
-   The version is determined using the installed package metadata,
-   by means of the standard `importlib.metadata`_ library.
 
    .. _`Python package`: https://docs.python.org/3/tutorial/modules.html#packages
-   .. _`importlib.metadata`: https://docs.python.org/3/library/importlib.metadata.html
 
 ``__main__.py``
    This module defines the ``__main__.main`` entry point
@@ -444,15 +439,11 @@ and they come in two types:
   These dependencies are not a part of distribution packages,
   because users do not require them to run your code.
 
-This project template has two core dependencies:
-
-- Click_, a library for creating command-line interfaces
-- `importlib_metadata`_, a backport of `importlib.metadata`_
+This project template has a core dependency on Click_,
+a library for creating command-line interfaces
 
 The project template also comes with a large number of development dependencies.
 See :ref:`features` for an overview.
-
-.. _`importlib_metadata`: https://importlib-metadata.readthedocs.io/
 
 
 Managing dependencies

--- a/{{cookiecutter.project_name}}/mypy.ini
+++ b/{{cookiecutter.project_name}}/mypy.ini
@@ -25,9 +25,6 @@ disallow_untyped_decorators = False
 [mypy-tests.*]
 disallow_untyped_decorators = False
 
-[mypy-importlib_metadata]
-ignore_missing_imports = True
-
 [mypy-nox.*]
 ignore_missing_imports = True
 

--- a/{{cookiecutter.project_name}}/poetry.lock
+++ b/{{cookiecutter.project_name}}/poetry.lock
@@ -357,7 +357,7 @@ networkx = "*"
 six = "*"
 
 [[package]]
-category = "main"
+category = "dev"
 description = "Read metadata from Python packages"
 marker = "python_version < \"3.8\""
 name = "importlib-metadata"
@@ -1068,7 +1068,7 @@ optional = ["pygments", "colorama"]
 tests = ["pytest", "pytest-cov", "codecov", "scikit-build", "cmake", "ninja", "pybind11"]
 
 [[package]]
-category = "main"
+category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
 name = "zipp"
@@ -1081,7 +1081,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "517a23852b7bb054137d1091dbaca69bf8b9e926abafdc140195d6f03ebe0b0c"
+content-hash = "65319d0edc4f6113f4da3d2d0399f624351bcf03d6b01be873ddfc0605a9f515"
 python-versions = "^3.6"
 
 [metadata.files]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -15,7 +15,6 @@ Changelog = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.proj
 [tool.poetry.dependencies]
 python = "^3.6"
 click = "^7.0"
-importlib-metadata = {version = "^1.5.0", python = "<3.8"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.2"

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -1,13 +1,1 @@
 """{{cookiecutter.friendly_name}}."""
-import sys
-
-if sys.version_info[:2] >= (3, 8):
-    from importlib.metadata import version, PackageNotFoundError  # pragma: no cover
-else:
-    from importlib_metadata import version, PackageNotFoundError  # pragma: no cover
-
-
-try:
-    __version__ = version(__name__)
-except PackageNotFoundError:  # pragma: no cover
-    __version__ = "unknown"

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__main__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__main__.py
@@ -1,11 +1,9 @@
 """Command-line interface."""
 import click
 
-from . import __version__
-
 
 @click.command()
-@click.version_option(version=__version__)
+@click.version_option()
 def main() -> None:
     """{{cookiecutter.friendly_name}}."""
 


### PR DESCRIPTION
There is no need to define `__version__` up front. Users have `importlib.metadata` if they need the version number.

Remove dependency on `importlib-metadata`, which is no longer needed.

By default, click.version_option determines the version using the installed package metadata. This is precisely where we get out `__version__` from, so there is no point passing it to version_option explicitly.

See https://hynek.me/articles/packaging-metadata/

cjolowicz/cookiecutter-hypermodern-python-instance#112