### PR TITLE
Configure Sphinx language to "en"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,7 @@ author = "Claudio Jolowicz"
 copyright = f"{datetime.now().year}, {author}"
 extensions = ["sphinx.ext.intersphinx"]
 intersphinx_mapping = {"mypy": ("https://mypy.readthedocs.io/en/stable/", None)}
+language = "en"
 html_static_path = ["_static"]
 html_theme = "alabaster"
 html_theme_options = {


### PR DESCRIPTION
Among other things, this sets the html lang attribute. With automatic
hyphenation, this ensures that the hyphenation rules for the correct
language are used (and that hyphenation occurs at all).