### PR TITLE
Use official pre-commit hooks instead of repository-local hooks

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1539,20 +1539,20 @@ consisting of the following hooks:
 .. _reorder-python-imports: https://github.com/asottile/reorder_python_imports
 .. _trailing-whitespace: https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace
 
-Black_, Flake8_, and mypy_ are run via Poetry using a `repository-local hook`_.
-This allows you to manage these tools as development dependencies in Poetry,
+mypy_ is run via Poetry using a `repository-local hook`_.
+This allows you to manage this tool as a development dependency in Poetry,
 rather than having duplicate and potentially diverging version pins in the pre-commit configuration.
 This does require you, however, to run `poetry install`_
 before you can use pre-commit with your project.
 
 .. _repository-local hook: https://pre-commit.com/#repository-local-hooks
 
-These checks run somewhat faster than the corresponding Nox sessions,
+This check runs somewhat faster than the corresponding Nox session,
 for several reasons:
 
-- They only run on files staged for a commit, by default.
-- They only run in the active Poetry environment.
-- They assume that the tools are already installed.
+- It only runs on files staged for a commit, by default.
+- It only runs in the active Poetry environment.
+- It assumes that the tool is already installed.
 
 
 Command-line usage

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
         additional_dependencies:
           - flake8-bandit==2.1.2
           - flake8-bugbear==20.1.4
+          - flake8-docstrings==1.5.0
   - repo: local
     hooks:
       - id: mypy

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -10,13 +10,12 @@ repos:
     rev: 2.0.5
     hooks:
       - id: prettier
-  - repo: local
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
     hooks:
       - id: black
-        name: black
-        entry: poetry run black
-        language: system
-        types: [python]
+  - repo: local
+    hooks:
       - id: flake8
         name: flake8
         entry: poetry run flake8

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
           - flake8-bandit==2.1.2
           - flake8-bugbear==20.1.4
           - flake8-docstrings==1.5.0
+          - flake8-rst-docstrings==0.0.13
   - repo: local
     hooks:
       - id: mypy

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
           - flake8-docstrings==1.5.0
           - flake8-rst-docstrings==0.0.13
           - pep8-naming==0.10.0
+          - darglint==1.2.3
   - repo: local
     hooks:
       - id: mypy

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
           - flake8-rst-docstrings==0.0.13
           - pep8-naming==0.10.0
           - darglint==1.2.3
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.3.0
+    hooks:
+      - id: reorder-python-imports
+        args: [--application-directories=src]
   - repo: local
     hooks:
       - id: mypy
@@ -33,8 +38,3 @@ repos:
         language: system
         types: [python]
         require_serial: true
-      - id: reorder-python-imports
-        name: reorder-python-imports
-        entry: poetry run reorder-python-imports --application-directories=src
-        language: system
-        types: [python]

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -14,13 +14,12 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-  - repo: local
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
     hooks:
       - id: flake8
-        name: flake8
-        entry: poetry run flake8
-        language: system
-        types: [python]
+  - repo: local
+    hooks:
       - id: mypy
         name: mypy
         entry: poetry run mypy

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -18,6 +18,8 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-bandit==2.1.2
   - repo: local
     hooks:
       - id: mypy

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-bandit==2.1.2
+          - flake8-bugbear==20.1.4
   - repo: local
     hooks:
       - id: mypy

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
           - flake8-bugbear==20.1.4
           - flake8-docstrings==1.5.0
           - flake8-rst-docstrings==0.0.13
+          - pep8-naming==0.10.0
   - repo: local
     hooks:
       - id: mypy

--- a/{{cookiecutter.project_name}}/poetry.lock
+++ b/{{cookiecutter.project_name}}/poetry.lock
@@ -24,17 +24,6 @@ version = "0.26.2"
 
 [[package]]
 category = "dev"
-description = "Utilities for refactoring imports in python-like syntax."
-name = "aspy.refactor-imports"
-optional = false
-python-versions = ">=3.6.1"
-version = "2.1.1"
-
-[package.dependencies]
-cached-property = "*"
-
-[[package]]
-category = "dev"
 description = "Atomic file writes."
 name = "atomicwrites"
 optional = false
@@ -1034,7 +1023,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "2bbff119fac705d50d5516f6f6a7cc4bcd12dd9d4c4cc4bd7262cc7527e6fd1d"
+content-hash = "71fdfa3292b6d8877b12bf42be34482a9a7a0908b94d0bee1cca975d67004071"
 python-versions = "^3.6.1"
 
 [metadata.files]
@@ -1049,10 +1038,6 @@ appdirs = [
 argh = [
     {file = "argh-0.26.2-py2.py3-none-any.whl", hash = "sha256:a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3"},
     {file = "argh-0.26.2.tar.gz", hash = "sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65"},
-]
-"aspy.refactor-imports" = [
-    {file = "aspy.refactor_imports-2.1.1-py2.py3-none-any.whl", hash = "sha256:9df76bf19ef81620068b785a386740ab3c8939fcbdcebf20c4a4e0057230d782"},
-    {file = "aspy.refactor_imports-2.1.1.tar.gz", hash = "sha256:eec8d1a73bedf64ffb8b589ad919a030c1fb14acf7d1ce0ab192f6eedae895c5"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -35,7 +35,6 @@ sphinx = "^3.0.3"
 pep8-naming = "^0.10.0"
 flake8-rst-docstrings = "^0.0.13"
 sphinx-autobuild = "^0.7.1"
-reorder-python-imports = "^2.2.0"
 pre-commit = "^2.3.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Use the official pre-commit hooks for flake8, black, and reorder-python-imports, instead of repository-local hooks. Add Flake8 plugins as additional dependencies to the flake8 hook.

Removing the Nox sessions and Poetry dependencies is left to follow-up PRs.
