### PR TITLE
Remove pre-commit hook for mypy

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1539,21 +1539,6 @@ consisting of the following hooks:
 .. _reorder-python-imports: https://github.com/asottile/reorder_python_imports
 .. _trailing-whitespace: https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace
 
-mypy_ is run via Poetry using a `repository-local hook`_.
-This allows you to manage this tool as a development dependency in Poetry,
-rather than having duplicate and potentially diverging version pins in the pre-commit configuration.
-This does require you, however, to run `poetry install`_
-before you can use pre-commit with your project.
-
-.. _repository-local hook: https://pre-commit.com/#repository-local-hooks
-
-This check runs somewhat faster than the corresponding Nox session,
-for several reasons:
-
-- It only runs on files staged for a commit, by default.
-- It only runs in the active Poetry environment.
-- It assumes that the tool is already installed.
-
 
 Command-line usage
 ------------------

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -30,11 +30,3 @@ repos:
     hooks:
       - id: reorder-python-imports
         args: [--application-directories=src]
-  - repo: local
-    hooks:
-      - id: mypy
-        name: mypy
-        entry: poetry run mypy
-        language: system
-        types: [python]
-        require_serial: true


### PR DESCRIPTION
The repository-local hook is problematic because it means that pre-commit needs to be able to run Poetry with a valid environment, introducing complexity and hidden dependencies.

The [official pre-commit] hook for mypy uses `--ignore-missing-imports` because it runs `mypy`
from an isolated virtualenv where imports for the dependencies are not accessible.

[official pre-commit]: https://github.com/pre-commit/mirrors-mypy

Running mypy from Nox means we can easily support multiple Python versions. This is
also possible with pre-commit, but leads to a lot of boilerplate.