### PR TITLE
Remove Nox session for Black

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -892,7 +892,7 @@ If you invoke Nox by itself, it will run the full test suite:
    $ nox
 
 This includes unit tests, linters, and type checkers,
-but excludes sessions like those for building documentation or for reformatting code.
+but excludes sessions like that for building documentation.
 The list of sessions run by default can be configured
 by editing ``nox.options.sessions`` in ``noxfile.py``.
 
@@ -937,7 +937,6 @@ The following table gives an overview of the available Nox sessions:
    ========================================== ============================== ================== =========
    Session                                    Description                    Python              Default
    ========================================== ============================== ================== =========
-   :ref:`black <The black session>`           Format code with Black_        ``3.8``
    :ref:`docs <The docs session>`             Build Sphinx_ documentation    ``3.8``
    :ref:`lint <The lint session>`             Lint with Flake8_              ``3.6`` … ``3.8``      ✓
    :ref:`mypy <The mypy session>`             Type-check with mypy_          ``3.6`` … ``3.8``      ✓
@@ -1294,8 +1293,6 @@ The flake8-black_ plugin
 checks adherence to the Black_ code style.
 `Error codes`__ are prefixed by ``BLK`` for "black".
 It generates a warning if it detects that Black would reformat a source file.
-You can fix these issues automatically,
-as described below in the section :ref:`Code formatting with Black`.
 
 .. _flake8-black codes:
 __ https://github.com/peterjc/flake8-black#flake8-validation-codes
@@ -1377,47 +1374,6 @@ as pytest_ uses assertions to verify expectations in tests.
 
 .. _Bandit codes:
 __ https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
-
-
-.. _Code formatting with Black:
-
-Code formatting with Black
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Black_ is the uncompromising Python code formatter.
-One of its greatest features is its lack of configurability.
-Blackened code looks the same regardless of the project you're reading.
-
-The *Hypermodern Python Cookiecutter*
-adheres to Black code style.
-
-
-.. _The black session:
-
-The black session
------------------
-
-Run the code formatter using the ``black`` session:
-
-.. code:: console
-
-   $ nox --session=black
-
-This session always runs with the current version of Python.
-
-Use the separator ``--`` to pass additional options to ``black``.
-For example, the following command formats a specific file:
-
-.. code:: console
-
-   $ nox --session=black -- noxfile.py
-
-By default, the code formatter runs on Python files in the following locations:
-
-- ``src``
-- ``tests``
-- ``noxfile.py``
-- ``docs/conf.py``
 
 
 Scanning dependencies with Safety

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -110,14 +110,6 @@ def install(session: Session, *args: str) -> None:
         session.install(f"--constraint={requirements}", *args)
 
 
-@nox.session(python="3.8")
-def black(session: Session) -> None:
-    """Run black code formatter."""
-    args = session.posargs or locations
-    install(session, "black")
-    session.run("black", *args)
-
-
 @nox.session(python=python_versions)
 def lint(session: Session) -> None:
     """Lint using flake8."""

--- a/{{cookiecutter.project_name}}/poetry.lock
+++ b/{{cookiecutter.project_name}}/poetry.lock
@@ -1023,7 +1023,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "71fdfa3292b6d8877b12bf42be34482a9a7a0908b94d0bee1cca975d67004071"
+content-hash = "8463a73adbdc3cbfd886c82dbe1f58bf4b1d4a316e8c513b20d064901ee6a8f0"
 python-versions = "^3.6.1"
 
 [metadata.files]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -21,7 +21,6 @@ pytest = "^5.3.2"
 coverage = {extras = ["toml"], version = "^5.1"}
 pytest-cov = "^2.8.1"
 flake8 = "^3.7.9"
-black = "^19.10b0"
 flake8-black = "^0.1.1"
 flake8-bugbear = "^20.1.2"
 flake8-bandit = "^2.1.2"


### PR DESCRIPTION
Remove the Nox session for Black, and remove its development dependency from Poetry. Black is now run as a pre-commit hook, so these are no longer useful.