### PR TITLE
Update and rework the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,7 +228,6 @@ Codecov
 
 1. Sign up at Codecov_.
 2. Install their GitHub app.
-3. Add your repository to Codecov.
 
 
 Dependabot

--- a/README.rst
+++ b/README.rst
@@ -273,7 +273,7 @@ Use labels to group the pull requests into sections:
 
 GitHub creates the ``bug``, ``enhancement``, and ``documentation`` labels for you.
 Dependabot creates the ``dependencies`` label.
-Create the remaining labels on the Issues tab of your GitHub repository,
+Create the remaining labels on the *Issues* tab of your GitHub repository,
 when you need them.
 
 .. table-release-drafter-sections-end

--- a/README.rst
+++ b/README.rst
@@ -256,7 +256,7 @@ Use labels to group the pull requests into sections:
    :widths: auto
 
    =================== ============================
-   Label               Section
+   Pull Request Label  Section in Release Notes
    =================== ============================
    ``breaking``        💥 Breaking Changes
    ``enhancement``     🚀 Features

--- a/README.rst
+++ b/README.rst
@@ -179,19 +179,6 @@ Install the pre-commit hooks:
    $ nox -s pre-commit -- install
 
 
-Installing
-----------
-
-First set up GitHub and PyPI, and release your project (see sections below).
-
-Install your project from PyPI, and run the command-line interface:
-
-.. code:: console
-
-   $ pipx install <project>
-   $ <project> --version
-
-
 Continuous Integration
 ----------------------
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1316,7 +1316,7 @@ Linting with pre-commit
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 pre-commit_ is a multi-language linter framework and a Git hook manager.
-pre-commit allows you to
+It allows you to
 integrate the best industry standard linters into your Git workflow,
 even when written in a language other than Python.
 Linters run in isolated environments managed by pre-commit.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -650,6 +650,9 @@ For these reasons, the lock file should be kept under source control.
 Using Poetry
 ~~~~~~~~~~~~
 
+Poetry_ manages packaging and dependencies for Python projects.
+
+
 .. _Managing dependencies:
 
 Managing dependencies

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -268,8 +268,47 @@ the project name uses hyphens (*snake case*),
 whereas the package name uses underscores (*kebab case*).
 
 
-Overview of generated files
----------------------------
+Uploading to GitHub
+-------------------
+
+This project template is designed for use with GitHub_.
+After generating the project,
+your next steps are to create a Git repository and upload it to GitHub.
+
+Change to the root directory of your new project,
+initialize a Git repository, and
+create a commit for the initial project structure:
+
+.. code:: console
+
+   $ git init
+   $ git add .
+   $ git commit
+
+Create an empty repository on GitHub_,
+using the project name you chose when you generated the project.
+
+.. note::
+
+   Do not include a ``README.md``, ``LICENSE``, or ``.gitignore``.
+   These files are provided by the project template.
+
+Finally, upload your repository to GitHub.
+In the commands below, replace ``<username>`` by your GitHub username,
+and ``<repository>`` by the name of your GitHub repository.
+
+.. code:: console
+
+   $ git remote add origin git@github.com:<username>/<repository>.git
+   $ git push --set-upstream origin master
+
+Now may be a good time to set up Continuous Integration for your repository.
+Refer to the section :ref:`Continuous Integration using GitHub Actions`
+for detailed instructions.
+
+
+Project overview
+~~~~~~~~~~~~~~~~
 
 This section provides an overview of all the files generated for your project.
 Let's start with the project layout.
@@ -444,45 +483,6 @@ under the ``src`` directory::
    (`PEP 561`_).
    This allows people using your package
    to type-check their Python code against it.
-
-
-Uploading to GitHub
--------------------
-
-This project template is designed for use with GitHub_.
-After generating the project,
-your next steps are to create a Git repository and upload it to GitHub.
-
-Change to the root directory of your new project,
-initialize a Git repository, and
-create a commit for the initial project structure:
-
-.. code:: console
-
-   $ git init
-   $ git add .
-   $ git commit
-
-Create an empty repository on GitHub_,
-using the project name you chose when you generated the project.
-
-.. note::
-
-   Do not include a ``README.md``, ``LICENSE``, or ``.gitignore``.
-   These files are provided by the project template.
-
-Finally, upload your repository to GitHub.
-In the commands below, replace ``<username>`` by your GitHub username,
-and ``<repository>`` by the name of your GitHub repository.
-
-.. code:: console
-
-   $ git remote add origin git@github.com:<username>/<repository>.git
-   $ git push --set-upstream origin master
-
-Now may be a good time to set up Continuous Integration for your repository.
-Refer to the section :ref:`Continuous Integration using GitHub Actions`
-for detailed instructions.
 
 
 Packaging

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1391,12 +1391,23 @@ Linters run in isolated environments managed by pre-commit.
 Using pre-commit
 ----------------
 
-pre-commit runs in a Nox session every time you invoke ``nox``.
+pre-commit runs in a Nox session every time you invoke ``nox``:
+
+.. code:: console
+
+   $ nox
+
 Run the pre-commit session explicitly like this:
 
 .. code:: console
 
    $ nox --session=pre-commit
+
+Install pre-commit as a Git hook by running the following command:
+
+.. code:: console
+
+   $ nox --session=pre-commit -- install
 
 When installed as a `Git hook`_,
 pre-commit runs automatically every time you invoke ``git commit``.
@@ -1404,12 +1415,6 @@ The commit is aborted if any check fails.
 When invoked in this mode, pre-commit only runs on files staged for the commit.
 
 .. _Git hook: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
-
-Install the Git hook by running the following command:
-
-.. code:: console
-
-   $ nox --session=pre-commit -- install
 
 Many linters support fixing offending lines automatically.
 When this happens,

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -310,6 +310,9 @@ for detailed instructions.
 Project overview
 ~~~~~~~~~~~~~~~~
 
+Files and directories
+---------------------
+
 This section provides an overview of all the files generated for your project.
 Let's start with the project layout.
 The project contains the following subdirectories:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1116,7 +1116,7 @@ The helper class has the following methods:
 
 
 Nox sessions
-~~~~~~~~~~~~
+------------
 
 .. _Table of Nox sessions:
 
@@ -1142,7 +1142,7 @@ The following table gives an overview of the available Nox sessions:
 .. _The docs session:
 
 The docs session
-----------------
+................
 
 Build the documentation using the Nox session ``docs``:
 
@@ -1179,7 +1179,7 @@ This Nox session always runs with the current major release of Python.
 .. _The mypy session:
 
 The mypy session
-----------------
+................
 
 mypy_ is the pioneer and *de facto* reference implementation of static type checking in Python.
 Learn more about it in the section :ref:`Type-checking with mypy`.
@@ -1209,7 +1209,7 @@ For example, the following command type-checks only the ``__main__`` module:
 .. _The pre-commit session:
 
 The pre-commit session
-----------------------
+......................
 
 pre-commit_ is a multi-language linter framework and a Git hook manager.
 Learn more about it in the section :ref:`Linting with pre-commit`.
@@ -1234,7 +1234,7 @@ so they run automatically on every commit you make:
 .. _The safety session:
 
 The safety session
-------------------
+..................
 
 Safety_ checks the dependencies of your project for known security vulnerabilities,
 using a curated database of insecure Python packages.
@@ -1257,7 +1257,7 @@ This session always runs with the current stable release of Python.
 .. _The tests session:
 
 The tests session
------------------
+.................
 
 Tests are written using the pytest_ testing framework.
 Learn more about it in the section :ref:`The test suite`.
@@ -1292,7 +1292,7 @@ For example, the following command runs only the test case ``test_main_succeeds`
 .. _The typeguard session:
 
 The typeguard session
----------------------
+.....................
 
 Typeguard_ is a runtime type checker and pytest_ plugin.
 It can type-check function calls during test runs via an `import hook`__.
@@ -1343,7 +1343,7 @@ For example, the following command runs only tests for the ``__main__`` module:
 .. _The xdoctest session:
 
 The xdoctest session
---------------------
+....................
 
 The xdoctest_ tool
 runs examples in your docstrings and

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1870,7 +1870,6 @@ Follow these steps to set up Codecov for your repository:
 
 1. Sign up at Codecov_.
 2. Install their GitHub app.
-3. Add your repository to Codecov.
 
 The configuration is included in the repository,
 in the file `codecov.yml`__.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -303,7 +303,7 @@ and ``<repository>`` by the name of your GitHub repository.
    $ git push --set-upstream origin master
 
 Now may be a good time to set up Continuous Integration for your repository.
-Refer to the section :ref:`Continuous Integration using GitHub Actions`
+Refer to the section :ref:`External services`
 for detailed instructions.
 
 
@@ -1833,6 +1833,8 @@ only direct dependencies are included.
    When adding or removing Sphinx extensions using Poetry,
    don't forget to update the requirements file as well.
 
+
+.. _External services:
 
 External services
 ~~~~~~~~~~~~~~~~~

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1781,18 +1781,28 @@ Type-checking with mypy
    For example, you can use type annotations to generate serialization schemas
    or command-line parsers.
 
+mypy_ is the pioneer and *de facto* reference implementation of static type checking in Python.
+
+
+Running mypy
+------------
+
+Run mypy via its Nox session.
+For details, see the section :ref:`The mypy session`.
+
 
 .. _Configuring mypy:
 
 Configuring mypy
 ----------------
 
-Configure mypy using the `mypy.ini`__ configuration file.
+Configure mypy using the ``mypy.ini`` configuration file in the project directory.
+For details about supported configuration options, see the `official reference`__.
 
 __ https://mypy.readthedocs.io/en/stable/config_file.html
 
-The |HPC| enables the strictness options
-(the options enabled by the :option:`--strict <mypy --strict>` flag):
+The |HPC| enables several configuration options which are off by default.
+The following options are enabled for strictness:
 
 - :option:`check_untyped_defs <mypy --check-untyped-defs>`
 - :option:`disallow_any_generics <mypy --disallow-any-generics>`

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1725,7 +1725,7 @@ Code coverage with Coverage.py
 
 *Test coverage* is a measure of the degree to which
 the source code of your program is executed while running its test suite.
-This project template requires full test coverage.
+The *Hypermodern Python Cookiecutter* requires full test coverage.
 
 Code coverage is measured using `Coverage.py`_.
 When the test suite completes,

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -373,7 +373,7 @@ and links each file to a section with more details.
    ``mypy.ini``                          Configuration for :ref:`mypy <Configuring mypy>`
    ``noxfile.py``                        Configuration for :ref:`Nox <Using Nox>`
    ``pyproject.toml``                    :ref:`Python package <The pyproject.toml file>` configuration,
-                                         and configuration for :ref:`Coverage.py <Test coverage>`
+                                         and configuration for :ref:`Coverage.py <Code coverage with Coverage.py>`
    ===================================== ========================================
 
 .. _.gitignore: https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring
@@ -1288,10 +1288,10 @@ a helper class for invoking the program from within tests.
 .. _click.testing.CliRunner: https://click.palletsprojects.com/en/7.x/testing/
 
 
-.. _Test coverage:
+.. _Code coverage with Coverage.py:
 
-Test coverage
--------------
+Code coverage with Coverage.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *Test coverage* is a measure of the degree to which
 the source code of your program is executed while running its test suite.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -517,6 +517,9 @@ a helper class for invoking the program from within tests.
 .. _click.testing.CliRunner: https://click.palletsprojects.com/en/7.x/testing/
 
 
+Packaging
+~~~~~~~~~
+
 .. _The pyproject.toml file:
 
 The pyproject.toml file

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1549,15 +1549,15 @@ and links to their lists of error codes.
 pyflakes
 --------
 
-The pyflakes_ tool
-parses Python source files and finds invalid code.
-`Error codes`__ are prefixed by ``F`` for "flake".
+pyflakes_ parses Python source files and finds invalid code.
 Warnings reported by this tool include
 syntax errors,
 undefined names,
 unused imports or variables,
 and more.
-The tool is included with Flake8_ by default.
+It is included with Flake8_ by default.
+
+`Error codes`__ are prefixed by ``F`` for "flake".
 
 .. _pyflakes codes:
 __ https://flake8.pycqa.org/en/latest/user/error-codes.html
@@ -1566,16 +1566,16 @@ __ https://flake8.pycqa.org/en/latest/user/error-codes.html
 pycodestyle
 -----------
 
-The pycodestyle_ tool
-checks your code against many recommendations from `PEP 8`_,
+pycodestyle_ checks your code against the style recommendations of `PEP 8`_,
 the official Python style guide.
-`Error codes`__ are prefixed by ``W`` for warnings and ``E`` for errors.
 The tool detects
 whitespace and indentation issues,
 deprecated features,
 bare excepts,
 and much more.
-The tool is included with Flake8_ by default.
+It is included with Flake8_ by default.
+
+`Error codes`__ are prefixed by ``W`` for warnings and ``E`` for errors.
 
 .. _pycodestyle codes:
 __ https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
@@ -1591,11 +1591,12 @@ for compatibility with Black_ and flake8-bugbear_:
 pep8-naming
 -----------
 
-The pep8-naming_ tool enforces the naming conventions from `PEP 8`_.
-`Error codes`__ are prefixed by ``N`` for "naming".
+pep8-naming_ enforces the naming conventions from `PEP 8`_.
 Examples are the use of camel case for the names of classes,
 the use of lowercase for the names of functions, arguments and variables,
 or the convention to name the first argument of methods ``self``.
+
+`Error codes`__ are prefixed by ``N`` for "naming".
 
 .. _pep8-naming codes:
 __ https://github.com/pycqa/pep8-naming#pep-8-naming-conventions
@@ -1604,13 +1605,13 @@ __ https://github.com/pycqa/pep8-naming#pep-8-naming-conventions
 pydocstyle and flake8-docstrings
 --------------------------------
 
-The pydocstyle_ tool is used to check that
-docstrings comply with the recommendations of `PEP 257`_
+pydocstyle_ checks that docstrings comply with the recommendations of `PEP 257`_
 and a configurable style convention.
-It is integrated via the flake8-docstrings_ extension.
-`Error codes`__ are prefixed by ``D`` for "docstring".
+It is integrated with Flake8 via the flake8-docstrings_ extension.
 Warnings range from missing docstrings to
 issues with whitespace, quoting, and docstring content.
+
+`Error codes`__ are prefixed by ``D`` for "docstring".
 
 .. _pydocstyle codes:
 __ http://www.pydocstyle.org/en/stable/error_codes.html
@@ -1638,10 +1639,10 @@ Here is an example of a function documented in Google style:
 flake8-rst-docstrings
 ---------------------
 
-The flake8-rst-docstrings_ plugin
-validates docstring markup as reStructuredText_ (reST).
-Docstrings must be valid reST---which includes most plain text---because
-they are used to generate API documentation.
+flake8-rst-docstrings_ validates docstring markup as reStructuredText_.
+Docstrings must be valid reStructuredText
+because they are used by Sphinx to generate the API reference.
+
 `Error codes`__ are prefixed by ``RST`` for "reStructuredText",
 and group issues into numerical blocks, by their severity and origin.
 
@@ -1653,11 +1654,15 @@ flake8-bugbear
 --------------
 
 flake8-bugbear_ detects bugs and design problems.
-`Error codes`__ are prefixed by ``B`` for "bugbear".
 The warnings are more opinionated than those of pyflakes or pycodestyle.
 For example,
 the plugin detects Python 2 constructs which have been removed in Python 3,
 and likely bugs such as function arguments defaulting to empty lists or dictionaries.
+
+`Error codes`__ are prefixed by ``B`` for "bugbear".
+
+.. _flake8-bugbear codes:
+__ https://github.com/PyCQA/flake8-bugbear#list-of-warnings
 
 The |HPC| also enables Bugbear's ``B9`` warnings,
 which are disabled by default.
@@ -1667,18 +1672,15 @@ but with a tolerance margin of 10%.
 This soft limit is set to 80 characters,
 which is the value used by the Black code formatter.
 
-.. _flake8-bugbear codes:
-__ https://github.com/PyCQA/flake8-bugbear#list-of-warnings
-
 
 mccabe
 ------
 
-The mccabe_ tool
-checks the `code complexity <Cyclomatic complexity_>`__
+mccabe_ checks the `code complexity <Cyclomatic complexity_>`__
 of your Python package against a configured limit.
+The tool is included with Flake8_.
+
 `Error codes`__ are prefixed by ``C`` for "complexity".
-It is included with Flake8_.
 
 .. _mccabe codes:
 __ https://github.com/PyCQA/mccabe#plugin-for-flake8
@@ -1693,17 +1695,18 @@ The |HPC| limits code complexity to a value of 10.
 darglint
 --------
 
-The darglint_ tool checks that docstring descriptions match function definitions.
-`Error codes`__ are prefixed by ``DAR`` for "darglint".
+darglint_ checks that docstring descriptions match function definitions.
 The tool has its own configuration file, named ``.darglint``.
+
+`Error codes`__ are prefixed by ``DAR`` for "darglint".
+
+.. _darglint codes:
+__ https://github.com/terrencepreilly/darglint#error-codes
 
 The |HPC| allows one-line docstrings without function signatures.
 Multi-line docstrings must
 specify the function signatures completely and correctly,
 using `Google docstring style`_.
-
-.. _darglint codes:
-__ https://github.com/terrencepreilly/darglint#error-codes
 
 
 Bandit
@@ -1712,15 +1715,16 @@ Bandit
 Bandit_ is a tool designed to
 find common security issues in Python code,
 and integrated via the flake8-bandit_ extension.
+
 `Error codes`__ are prefixed by ``S`` for "security".
 (The prefix ``B`` for "bandit" is used
 when Bandit is run as a stand-alone tool.)
 
-The |HPC| disables ``S101`` (use of assert) for the test suite,
-as pytest_ uses assertions to verify expectations in tests.
-
 .. _Bandit codes:
 __ https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
+
+The |HPC| disables ``S101`` (use of assert) for the test suite,
+as pytest_ uses assertions to verify expectations in tests.
 
 
 .. _Code coverage with Coverage.py:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1404,12 +1404,6 @@ using the Flake8_ linter framework.
 The configuration file for Flake8 and its extensions
 is named ``.flake8`` and located in the project directory.
 
-
-.. _Available linters:
-
-Available linters
------------------
-
 Flake8 comes with a rich ecosystem of extensions.
 The following table lists the Flake8 plugins used by
 the *Hypermodern Python Cookiecutter*,
@@ -1434,16 +1428,13 @@ and links to their lists of error codes.
    ======================= ============================================================== ======================================
 
 
-The linters
------------
-
-This section describes the linters in more detail.
+The following sections describe the linters in more detail.
 Each section also notes any configuration settings applied by
 the *Hypermodern Python Cookiecutter*.
 
 
 pyflakes
-........
+--------
 
 The pyflakes_ tool
 parses Python source files and finds invalid code.
@@ -1460,7 +1451,7 @@ __ https://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
 pycodestyle
-...........
+-----------
 
 The pycodestyle_ tool
 checks your code against many recommendations from `PEP 8`_,
@@ -1485,7 +1476,7 @@ for compatibility with Black_ and flake8-bugbear_:
 
 
 pep8-naming
-...........
+-----------
 
 The pep8-naming_ tool enforces the naming conventions from `PEP 8`_.
 `Error codes`__ are prefixed by ``N`` for "naming".
@@ -1498,7 +1489,7 @@ __ https://github.com/pycqa/pep8-naming#pep-8-naming-conventions
 
 
 pydocstyle and flake8-docstrings
-................................
+--------------------------------
 
 The pydocstyle_ tool is used to check that
 docstrings comply with the recommendations of `PEP 257`_
@@ -1533,7 +1524,7 @@ Here is an example of a function documented in Google style:
 
 
 flake8-rst-docstrings
-.....................
+---------------------
 
 The flake8-rst-docstrings_ plugin
 validates docstring markup as reStructuredText_ (reST).
@@ -1547,7 +1538,7 @@ __ https://github.com/peterjc/flake8-rst-docstrings#flake8-validation-codes
 
 
 flake8-bugbear
-..............
+--------------
 
 flake8-bugbear_ detects bugs and design problems.
 `Error codes`__ are prefixed by ``B`` for "bugbear".
@@ -1570,7 +1561,7 @@ __ https://github.com/PyCQA/flake8-bugbear#list-of-warnings
 
 
 mccabe
-......
+------
 
 The mccabe_ tool
 checks the `code complexity <Cyclomatic complexity_>`__
@@ -1590,7 +1581,7 @@ limits code complexity to a value of 10.
 .. _darglint integration:
 
 darglint
-........
+--------
 
 The darglint_ tool checks that docstring descriptions match function definitions.
 `Error codes`__ are prefixed by ``DAR`` for "darglint".
@@ -1607,7 +1598,7 @@ __ https://github.com/terrencepreilly/darglint#error-codes
 
 
 Bandit
-......
+------
 
 Bandit_ is a tool designed to
 find common security issues in Python code,

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1971,7 +1971,6 @@ GitHub Actions workflows install the following tools:
 - pip_
 - Poetry_
 - Nox_
-- pre-commit_
 
 These dependencies are pinned using a `constraints file`_
 located in ``.github/workflow/constraints.txt``.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -550,24 +550,6 @@ for a detailed description of each configuration key.
 Dependencies
 ------------
 
-.. note::
-
-   Dependencies are Python packages used by your project,
-   and they come in two types:
-
-   - *Core dependencies* are required by users running your code,
-     and typically consist of third-party libraries imported by your package.
-     When your package is distributed,
-     the package metainfo includes these dependencies,
-     allowing tools like pip_ to automatically install them alongside your package.
-
-   - *Development dependencies* are only required by developers working on your code.
-     Examples are applications used to run tests,
-     check code for style and correctness,
-     or to build documentation.
-     These dependencies are not a part of distribution packages,
-     because users do not require them to run your code.
-
 This project template has a core dependency on Click_,
 a library for creating command-line interfaces.
 The template also comes with various development dependencies.
@@ -592,6 +574,24 @@ See the table below for an overview of the dependencies of generated projects:
    ================= =====================================================
 
 __ Coverage.py_
+
+.. note::
+
+   Dependencies are Python packages used by your project,
+   and they come in two types:
+
+   - *Core dependencies* are required by users running your code,
+     and typically consist of third-party libraries imported by your package.
+     When your package is distributed,
+     the package metainfo includes these dependencies,
+     allowing tools like pip_ to automatically install them alongside your package.
+
+   - *Development dependencies* are only required by developers working on your code.
+     Examples are applications used to run tests,
+     check code for style and correctness,
+     or to build documentation.
+     These dependencies are not a part of distribution packages,
+     because users do not require them to run your code.
 
 
 Version constraints

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1388,6 +1388,10 @@ integrate the best industry standard linters into your Git workflow,
 even when written in a language other than Python.
 Linters run in isolated environments managed by pre-commit.
 
+
+Using pre-commit
+----------------
+
 pre-commit runs in a Nox session every time you invoke ``nox``.
 Run the pre-commit session explicitly like this:
 
@@ -1414,6 +1418,10 @@ your original changes are in the staging area,
 while the linter fixes are in the work tree.
 You can accept the fixes by staging them with ``git add``
 before committing again.
+
+
+Overview of pre-commit hooks
+----------------------------
 
 pre-commit is configured using the file ``.pre-commit-config.yaml``
 in the project directory.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -19,8 +19,7 @@ Introduction
 About this project
 ------------------
 
-The *Hypermodern Python Cookiecutter* is
-a general-purpose template for Python libraries and applications,
+The |HPC| is a general-purpose template for Python libraries and applications,
 released under the `MIT license`_
 and hosted on `GitHub <Hypermodern Python Cookiecutter_>`__.
 
@@ -60,7 +59,7 @@ Here is a detailed list of features for this Python template:
 Release cadence
 ---------------
 
-The *Hypermodern Python Cookiecutter* has a bimonthly_ release cadence.
+The |HPC| has a bimonthly_ release cadence.
 Releases happen on the 15th of every other month, starting in January.
 We use `Calendar Versioning`_ with a ``YYYY.MM.DD`` versioning scheme.
 Initial releases may occur more frequently.
@@ -783,7 +782,7 @@ in the ``pyproject.toml`` file.
 
 .. note::
 
-   Dependencies in the *Hypermodern Python Cookiecutter* are managed by :ref:`Dependabot <Dependabot integration>`.
+   Dependencies in the |HPC| are managed by :ref:`Dependabot <Dependabot integration>`.
    When newer versions of dependencies become available,
    Dependabot updates the ``pyproject.toml`` and ``poetry.lock`` files and submits a pull request.
 
@@ -908,7 +907,7 @@ Building and distributing the package
 
 .. note::
 
-   With the *Hypermodern Python Cookiecutter*,
+   With the |HPC|,
    building and distributing your package
    is taken care of by `GitHub Actions`_
    when you publish a `GitHub Release`_.
@@ -1169,7 +1168,7 @@ The safety session
 
 Safety_ checks the dependencies of your project for known security vulnerabilities,
 using a curated database of insecure Python packages.
-The *Hypermodern Python Cookiecutter* uses the `poetry export`_ command
+The |HPC| uses the `poetry export`_ command
 to convert Poetry's lock file to a `requirements file`_,
 for consumption by Safety.
 
@@ -1430,9 +1429,7 @@ for details about the configuration file.
 
 __ https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 
-The *Hypermodern Python Cookiecutter* comes with
-a pre-commit configuration
-consisting of the following hooks:
+The |HPC| comes with a pre-commit configuration consisting of the following hooks:
 
 .. table:: pre-commit hooks
    :class: hypermodern-table
@@ -1470,7 +1467,7 @@ The Prettier hook
 Prettier_ is an opinionated code formatter for many languages,
 including YAML, Markdown, and JavaScript.
 Like Black, it has few options,
-and the *Hypermodern Python Cookiecutter* uses none of them.
+and the |HPC| uses none of them.
 
 
 .. _The Flake8 hook:
@@ -1517,16 +1514,14 @@ For details about the configuration file, see the `official reference`__.
 __ https://flake8.pycqa.org/en/latest/user/configuration.html
 
 The sections below describe the linters in more detail.
-Each section also notes any configuration settings applied by
-the *Hypermodern Python Cookiecutter*.
+Each section also notes any configuration settings applied by the |HPC|.
 
 
 Plugin overview
 ---------------
 
 Flake8 comes with a rich ecosystem of plugins.
-The following table lists the Flake8 plugins used by
-the *Hypermodern Python Cookiecutter*,
+The following table lists the Flake8 plugins used by the |HPC|,
 and links to their lists of error codes.
 
 .. table:: Flake8 plugins
@@ -1580,7 +1575,7 @@ The tool is included with Flake8_ by default.
 .. _pycodestyle codes:
 __ https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 
-The *Hypermodern Python Cookiecutter* disables the following errors and warnings
+The |HPC| disables the following errors and warnings
 for compatibility with Black_ and flake8-bugbear_:
 
 - ``E203`` (whitespace before ``:``)
@@ -1615,8 +1610,7 @@ issues with whitespace, quoting, and docstring content.
 .. _pydocstyle codes:
 __ http://www.pydocstyle.org/en/stable/error_codes.html
 
-The *Hypermodern Python Cookiecutter*
-selects the recommendations of the
+The |HPC| selects the recommendations of the
 `Google styleguide <Google docstring style_>`__.
 Here is an example of a function documented in Google style:
 
@@ -1660,8 +1654,7 @@ For example,
 the plugin detects Python 2 constructs which have been removed in Python 3,
 and likely bugs such as function arguments defaulting to empty lists or dictionaries.
 
-The *Hypermodern Python Cookiecutter*
-also enables Bugbear's ``B9`` warnings,
+The |HPC| also enables Bugbear's ``B9`` warnings,
 which are disabled by default.
 In particular, ``B950`` checks the maximum line length
 like pycodestyle_'s ``E501``,
@@ -1685,8 +1678,7 @@ It is included with Flake8_.
 .. _mccabe codes:
 __ https://github.com/PyCQA/mccabe#plugin-for-flake8
 
-The *Hypermodern Python Cookiecutter*
-limits code complexity to a value of 10.
+The |HPC| limits code complexity to a value of 10.
 
 .. _Cyclomatic complexity: https://en.wikipedia.org/wiki/Cyclomatic_complexity
 
@@ -1700,8 +1692,7 @@ The darglint_ tool checks that docstring descriptions match function definitions
 `Error codes`__ are prefixed by ``DAR`` for "darglint".
 The tool has its own configuration file, named ``.darglint``.
 
-The *Hypermodern Python Cookiecutter*
-allows one-line docstrings without function signatures.
+The |HPC| allows one-line docstrings without function signatures.
 Multi-line docstrings must
 specify the function signatures completely and correctly,
 using `Google docstring style`_.
@@ -1720,8 +1711,7 @@ and integrated via the flake8-bandit_ extension.
 (The prefix ``B`` for "bandit" is used
 when Bandit is run as a stand-alone tool.)
 
-The *Hypermodern Python Cookiecutter*
-disables ``S101`` (use of assert) for the test suite,
+The |HPC| disables ``S101`` (use of assert) for the test suite,
 as pytest_ uses assertions to verify expectations in tests.
 
 .. _Bandit codes:
@@ -1735,7 +1725,7 @@ Code coverage with Coverage.py
 
 *Test coverage* is a measure of the degree to which
 the source code of your program is executed while running its test suite.
-The *Hypermodern Python Cookiecutter* requires full test coverage.
+The |HPC| requires full test coverage.
 
 Code coverage is measured using `Coverage.py`_.
 When the test suite completes,
@@ -1790,7 +1780,7 @@ Configure mypy using the `mypy.ini`__ configuration file.
 
 __ https://mypy.readthedocs.io/en/stable/config_file.html
 
-The *Hypermodern Python Cookiecutter* enables the strictness options
+The |HPC| enables the strictness options
 (the options enabled by the :option:`--strict <mypy --strict>` flag):
 
 - :option:`check_untyped_defs <mypy --check-untyped-defs>`
@@ -1954,7 +1944,7 @@ Your documentation now has a public URL like this:
 
 The configuration for Read the Docs is included in the repository,
 in the file `.readthedocs.yml`__.
-The *Hypermodern Python Cookiecutter* configures Read the Docs
+The |HPC| configures Read the Docs
 to build and install the package with Poetry,
 using a so-called `PEP 517`_-build.
 
@@ -1981,7 +1971,7 @@ only direct dependencies are included.
 GitHub Actions workflows
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The *Hypermodern Python Cookiecutter* uses `GitHub Actions`_
+The |HPC| uses `GitHub Actions`_
 to implement continuous integration and delivery.
 With GitHub Actions,
 you define so-called workflows
@@ -2008,8 +1998,7 @@ __ https://help.github.com/en/actions/automating-your-workflow-with-github-actio
 Overview of workflows
 ---------------------
 
-The *Hypermodern Python Cookiecutter* defines
-the following workflows:
+The |HPC| defines the following workflows:
 
 .. table:: GitHub Actions workflows
    :class: hypermodern-table
@@ -2170,7 +2159,7 @@ The workflow is triggered on every push to the master branch.
 It includes details from every pull request merged into master since the last release.
 The workflow uses the `Release Drafter`_ GitHub Action.
 
-The *Hypermodern Python Cookiecutter* groups pull requests by type,
+The |HPC| groups pull requests by type,
 using GitHub labels.
 The following table shows the section headings and corresponding labels:
 
@@ -2435,6 +2424,8 @@ __ https://medium.com/@cjolowicz/hypermodern-python-6-ci-cd-b233accfa2f6
 You can also read the articles on `this blog`__.
 
 __ https://cjolowicz.github.io/posts/hypermodern-python-01-setup/
+
+.. |HPC| replace:: *Hypermodern Python Cookiecutter*
 
 .. include:: ../README.rst
    :start-after: references-begin

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -339,7 +339,7 @@ For more details on these files, refer to the section :ref:`The initial package`
    ===================================== ===============================
 
 The test suite is located in the ``tests`` directory.
-For more details on these files, refer to the section :ref:`Testing with pytest`.
+For more details on these files, refer to the section :ref:`The test suite`.
 
 .. table:: Test suite
    :class: hypermodern-table
@@ -483,6 +483,35 @@ under the ``src`` directory::
    (`PEP 561`_).
    This allows people using your package
    to type-check their Python code against it.
+
+
+.. _The test suite:
+
+The test suite
+--------------
+
+Tests are written using the pytest_ testing framework,
+the *de facto* standard for testing in Python.
+
+The test suite is located in the ``tests`` directory::
+
+   tests
+   ├── __init__.py
+   └── test_main.py
+
+The test suite is `declared as a package`__,
+and mirrors the source layout of the package under test.
+The file ``test_main.py`` contains tests for the ``__main__`` module.
+
+__ http://doc.pytest.org/en/latest/goodpractices.html#tests-outside-application-code
+
+Initially, the test suite contains a single test case,
+checking whether the program exits with a status code of zero.
+It also provides a `test fixture`_ using `click.testing.CliRunner`_,
+a helper class for invoking the program from within tests.
+
+.. _test fixture: https://docs.pytest.org/en/latest/fixture.html
+.. _click.testing.CliRunner: https://click.palletsprojects.com/en/7.x/testing/
 
 
 Packaging
@@ -1141,7 +1170,7 @@ The tests session
 -----------------
 
 Tests are written using the pytest_ testing framework.
-Learn more about it in the section :ref:`Testing with pytest`.
+Learn more about it in the section :ref:`The test suite`.
 
 Run the test suite using the Nox session ``tests``:
 
@@ -1256,35 +1285,6 @@ or run specific examples:
 .. code:: console
 
    $ nox --session=xdoctest -- list
-
-
-.. _Testing with pytest:
-
-Testing with pytest
-~~~~~~~~~~~~~~~~~~~
-
-Tests are written using the pytest_ testing framework,
-the *de facto* standard for testing in Python.
-
-The test suite is located in the ``tests`` directory::
-
-   tests
-   ├── __init__.py
-   └── test_main.py
-
-The test suite is `declared as a package`__,
-and mirrors the source layout of the package under test.
-The file ``test_main.py`` contains tests for the ``__main__`` module.
-
-__ http://doc.pytest.org/en/latest/goodpractices.html#tests-outside-application-code
-
-Initially, the test suite contains a single test case,
-checking whether the program exits with a status code of zero.
-It also provides a `test fixture`_ using `click.testing.CliRunner`_,
-a helper class for invoking the program from within tests.
-
-.. _test fixture: https://docs.pytest.org/en/latest/fixture.html
-.. _click.testing.CliRunner: https://click.palletsprojects.com/en/7.x/testing/
 
 
 .. _Code coverage with Coverage.py:
@@ -2243,7 +2243,7 @@ How to make code changes
 
 1. | Run the tests, :ref:`as explained above <How to test your project>`.
    | All tests should pass.
-2. | Add a failing test :ref:`under the tests directory <Testing with pytest>`.
+2. | Add a failing test :ref:`under the tests directory <The test suite>`.
    | Run the tests again to verify that your test fails.
 3. | Make your changes to the package, :ref:`under the src directory <The initial package>`.
    | Run the tests to verify that all tests pass again.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -527,6 +527,8 @@ Building and distributing the package
    building and distributing your package
    is taken care of by `GitHub Actions`_
    when you publish a `GitHub Release`_.
+   For more information,
+   see the section :ref:`The Release workflow`.
 
 This section gives a short overview of
 how you can build and distribute your package

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -547,6 +547,53 @@ for a detailed description of each configuration key.
 .. _pyproject.toml: https://python-poetry.org/docs/pyproject/
 
 
+Dependencies
+------------
+
+.. note::
+
+   Dependencies are Python packages used by your project,
+   and they come in two types:
+
+   - *Core dependencies* are required by users running your code,
+     and typically consist of third-party libraries imported by your package.
+     When your package is distributed,
+     the package metainfo includes these dependencies,
+     allowing tools like pip_ to automatically install them alongside your package.
+
+   - *Development dependencies* are only required by developers working on your code.
+     Examples are applications used to run tests,
+     check code for style and correctness,
+     or to build documentation.
+     These dependencies are not a part of distribution packages,
+     because users do not require them to run your code.
+
+This project template has a core dependency on Click_,
+a library for creating command-line interfaces.
+The template also comes with various development dependencies.
+See the table below for an overview of the dependencies of generated projects:
+
+.. table:: Dependencies
+   :class: hypermodern-table
+   :widths: auto
+
+   ================= =====================================================
+   click_            Composable command line interface toolkit
+   coverage__        Code coverage measurement for Python
+   mypy_             Optional static typing for Python
+   pre-commit_       A framework for managing and maintaining multi-language pre-commit hooks
+   pytest_           Simple powerful testing with Python
+   pytest-cov_       Pytest plugin for measuring coverage
+   safety_           Checks installed dependencies for known vulnerabilities
+   sphinx_           Python documentation generator
+   sphinx-autobuild_ Watch a Sphinx directory and rebuild the documentation when a change is detected
+   typeguard_        Run-time type checker for Python
+   xdoctest_         A rewrite of the builtin doctest module
+   ================= =====================================================
+
+__ Coverage.py_
+
+
 Version constraints
 -------------------
 
@@ -598,53 +645,6 @@ The lock file is useful for a number of reasons:
 .. _dev-prod parity: https://12factor.net/dev-prod-parity
 
 For these reasons, the lock file should be kept under source control.
-
-
-Dependencies
-------------
-
-.. note::
-
-   Dependencies are Python packages used by your project,
-   and they come in two types:
-
-   - *Core dependencies* are required by users running your code,
-     and typically consist of third-party libraries imported by your package.
-     When your package is distributed,
-     the package metainfo includes these dependencies,
-     allowing tools like pip_ to automatically install them alongside your package.
-
-   - *Development dependencies* are only required by developers working on your code.
-     Examples are applications used to run tests,
-     check code for style and correctness,
-     or to build documentation.
-     These dependencies are not a part of distribution packages,
-     because users do not require them to run your code.
-
-This project template has a core dependency on Click_,
-a library for creating command-line interfaces.
-The template also comes with various development dependencies.
-See the table below for an overview of the dependencies of generated projects:
-
-.. table:: Dependencies
-   :class: hypermodern-table
-   :widths: auto
-
-   ================= =====================================================
-   click_            Composable command line interface toolkit
-   coverage__        Code coverage measurement for Python
-   mypy_             Optional static typing for Python
-   pre-commit_       A framework for managing and maintaining multi-language pre-commit hooks
-   pytest_           Simple powerful testing with Python
-   pytest-cov_       Pytest plugin for measuring coverage
-   safety_           Checks installed dependencies for known vulnerabilities
-   sphinx_           Python documentation generator
-   sphinx-autobuild_ Watch a Sphinx directory and rebuild the documentation when a change is detected
-   typeguard_        Run-time type checker for Python
-   xdoctest_         A rewrite of the builtin doctest module
-   ================= =====================================================
-
-__ Coverage.py_
 
 
 Using Poetry

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -462,7 +462,7 @@ under the ``src`` directory::
    and supports ``--help`` and ``--version`` options.
    When the package is installed,
    a script named ``<project>`` is placed
-   in the ``bin`` directory of the Python installation or virtual environment.
+   in the Python installation or virtual environment.
    This allows you to invoke the command-line interface using only the project name:
 
    .. code:: console

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -810,7 +810,7 @@ You can also run developer tools, such as pytest_:
 
 While it is handy to have developer tools available in the Poetry environment,
 it is usually recommended to run these using Nox,
-as described in the next section.
+as described in the section :ref:`Using Nox`.
 
 
 Building and distributing the package

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1524,8 +1524,8 @@ The sections below describe the linters in more detail.
 Each section also notes any configuration settings applied by the |HPC|.
 
 
-Plugin overview
----------------
+Overview of available plugins
+-----------------------------
 
 Flake8 comes with a rich ecosystem of plugins.
 The following table lists the Flake8 plugins used by the |HPC|,

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -353,27 +353,35 @@ For more details on these files, refer to the section :ref:`The test suite`.
    ``tests/test_main.py``                Test cases for ``__main__``
    ===================================== ===============================
 
-The project documentation is written in `reStructuredText`_.
-The documentation files in the top-level directory are rendered on `GitHub`_.
-The files in the ``docs`` directory are
-built using :ref:`Sphinx <Sphinx documentation>` and
-hosted on :ref:`Read the Docs <Read the Docs integration>`.
+The project documentation is written in reStructuredText_.
+The documentation files in the top-level directory are rendered on GitHub_:
 
-.. table:: Documentation files
+.. table:: Documentation files (top-level)
    :class: hypermodern-table
    :widths: auto
 
-   ===================================== ===============================
-   ``CODE_OF_CONDUCT.rst``               Code of Conduct
-   ``CONTRIBUTING.rst``                  Contributor Guide
-   ``LICENSE.rst``                       License
-   ``README.rst``                        Main page
-   ``docs/codeofconduct.rst``            Code of Conduct (included)
-   ``docs/contributing.rst``             Contributor Guide (included)
-   ``docs/index.rst``                    Main page
-   ``docs/license.rst``                  License (included)
-   ``docs/reference.rst``                API reference
-   ===================================== ===============================
+   ======================= ============================================
+   ``README.rst``          Project description for GitHub and PyPI
+   ``CONTRIBUTING.rst``    Contributor Guide
+   ``CODE_OF_CONDUCT.rst`` Code of Conduct
+   ``LICENSE.rst``         License
+   ======================= ============================================
+
+The files in the ``docs`` directory are
+built using :ref:`Sphinx <Documentation>` and
+hosted on :ref:`Read the Docs <Read the Docs integration>`:
+
+.. table:: Documentation files (Sphinx)
+   :class: hypermodern-table
+   :widths: auto
+
+   ====================== =======================================================
+   ``index.rst``          Master document
+   ``contributing.rst``   Contributor Guide (via include)
+   ``codeofconduct.rst``  Code of Conduct (via include)
+   ``license.rst``        License (via include)
+   ``reference.rst``      API reference
+   ====================== =======================================================
 
 The ``.github/workflows`` directory contains the :ref:`GitHub Actions workflows <GitHub Actions workflows>`:
 
@@ -390,9 +398,8 @@ The ``.github/workflows`` directory contains the :ref:`GitHub Actions workflows 
    ``tests.yml``           :ref:`The Tests workflow`
    ======================= ===============================
 
-The project contains many configuration files for developer tools,
-most of which are located in the top-level directory
-and have names with a leading dot.
+The project contains many configuration files for developer tools.
+Most of these are located in the top-level directory.
 The table below lists these files,
 and links each file to a section with more details.
 
@@ -411,7 +418,7 @@ and links each file to a section with more details.
    ``.pre-commit-config.yaml``           Configuration for :ref:`pre-commit <Linting with pre-commit>`
    ``.readthedocs.yml``                  Configuration for :ref:`Read the Docs <Read the Docs integration>`
    ``codecov.yml``                       Configuration for :ref:`Codecov <Codecov integration>`
-   ``docs/conf.py``                      Configuration for :ref:`Sphinx <Sphinx documentation>`
+   ``docs/conf.py``                      Configuration for :ref:`Sphinx <Documentation>`
    ``mypy.ini``                          Configuration for :ref:`mypy <Configuring mypy>`
    ``noxfile.py``                        Configuration for :ref:`Nox <Using Nox>`
    ``pyproject.toml``                    :ref:`Python package <The pyproject.toml file>` configuration,
@@ -515,6 +522,82 @@ a helper class for invoking the program from within tests.
 
 .. _test fixture: https://docs.pytest.org/en/latest/fixture.html
 .. _click.testing.CliRunner: https://click.palletsprojects.com/en/7.x/testing/
+
+For details on how to run the test suite,
+refer to the section :ref:`The tests session`.
+
+
+.. _Documentation:
+
+Documentation
+-------------
+
+The project documentation is written in reStructuredText_
+and processed by the Sphinx_ documentation engine.
+
+The top-level directory contains several stand-alone documentation files:
+
+``README.rst``
+   This file is your main project page and displayed on GitHub and PyPI.
+
+``CONTRIBUTING.rst``
+   The Contributor Guide explains how other people can contribute to your project.
+
+``CODE_OF_CONDUCT.rst``
+   The Code of Conduct outlines the behavior
+   expected from participants of your project.
+   It is adapted from the `Contributor Covenant`_, version 2.0.
+
+.. _Contributor Covenant: https://www.contributor-covenant.org
+
+``LICENSE.rst``
+   This file contains the text of the `MIT license`_, a simple permissive license.
+
+.. note::
+
+   The files above are also rendered on GitHub and PyPI.
+   Keep them in plain reStructuredText, without Sphinx extensions.
+
+The documentation files in the ``docs`` directory are built using Sphinx_:
+
+``index.rst``
+   This is the master document,
+   and serves as the main documentation page.
+   This file also defines the navigation menu,
+   with links to other documentation pages.
+   The *Changelog* menu entry
+   links to the `GitHub Releases <GitHub Release_>`__ page of your project.
+
+``contributing.rst``
+   This file includes the Contributor Guide from ``CONTRIBUTING.rst``.
+
+``codeofconduct.rst``
+   This file includes the Code of Conduct from ``CODE_OF_CONDUCT.rst``.
+
+``license.rst``
+   This file includes the license from ``LICENSE.rst``.
+
+``reference.rst``
+   The API reference for your project.
+   It is generated from docstrings and type annotations in the source code,
+   using the autodoc_ and napoleon_ extensions.
+
+The ``docs`` directory contains two more files:
+
+``conf.py``
+   This Python file contains the `Sphinx configuration`__.
+
+__ https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+``requirements.txt``
+   The requirements file pins the build dependencies for the Sphinx documentation.
+   This file is only used on Read the Docs.
+
+The project documentation is built and hosted on
+:ref:`Read the Docs <Read the Docs integration>`.
+
+You can also build the documentation locally using Nox,
+see :ref:`The docs session`.
 
 
 Packaging
@@ -1716,82 +1799,6 @@ The following options are enabled for enhanced output:
 - :option:`show_column_numbers <mypy --show-column-numbers>`
 - :option:`show_error_codes <mypy --show-error-codes>`
 - :option:`show_error_context <mypy --show-error-context>`
-
-
-Documentation with Sphinx and Read the Docs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Stand-alone documents
----------------------
-
-The project repository contains several stand-alone documentation files
-written in reStructuredText_:
-
-.. table:: Documentation files
-   :class: hypermodern-table
-   :widths: auto
-
-   ======================= ============================================
-   ``README.rst``          Project description for GitHub and PyPI
-   ``CONTRIBUTING.rst``    Contributor Guide
-   ``CODE_OF_CONDUCT.rst`` Code of Conduct
-   ``LICENSE.rst``         License
-   ======================= ============================================
-
-
-.. _Sphinx documentation:
-
-Sphinx documentation
---------------------
-
-The project documentation itself lives under ``docs``.
-It is written in reStructuredText_,
-processed by Sphinx_,
-and accessible on `Read the Docs`_.
-It consists of the following files in the ``docs`` directory:
-
-.. table:: Sphinx documentation files
-   :class: hypermodern-table
-   :widths: auto
-
-   ====================== =======================================================
-   ``index.rst``          Master document
-   ``contributing.rst``   Contributor Guide (includes ``CONTRIBUTING.rst``)
-   ``codeofconduct.rst``  Code of Conduct (includes ``CODE_OF_CONDUCT.rst``)
-   ``license.rst``        License (includes ``LICENSE.rst``)
-   ``reference.rst``      API documentation
-   ====================== =======================================================
-
-The documentation menu also has a *Changelog* entry,
-which links to the `GitHub Releases <GitHub Release_>`__ page.
-
-The API documentation is generated from docstrings and type annotations
-using the autodoc_ and napoleon_ extensions.
-
-You can build the documentation locally using Nox,
-see :ref:`The docs session`.
-
-
-Configuring Sphinx
-------------------
-
-The ``docs`` directory contains two more files:
-
-.. table:: Sphinx configuration files
-   :class: hypermodern-table
-   :widths: auto
-
-   ====================== =======================================================
-   ``conf.py``            Sphinx configuration file
-   ``requirements.txt``   Build dependencies for `Read the Docs`_
-   ====================== =======================================================
-
-The ``conf.py`` file contains the `Sphinx configuration`__.
-
-__ https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-The ``requirements.txt`` file pins the build dependencies for the Sphinx documentation.
-This file is only used on :ref:`Read the Docs <Read the Docs integration>`.
 
 
 .. _External services:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -314,10 +314,10 @@ Files and directories
 ---------------------
 
 This section provides an overview of all the files generated for your project.
-Let's start with the project layout.
-The project contains the following subdirectories:
 
-.. table:: Project layout
+Let's start with the directory layout:
+
+.. table:: Directories
    :class: hypermodern-table
    :widths: auto
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -576,102 +576,8 @@ See the table below for an overview of the dependencies of generated projects:
 __ Coverage.py_
 
 
-Packaging
-~~~~~~~~~
-
-Building and distributing the package
--------------------------------------
-
-.. note::
-
-   With the *Hypermodern Python Cookiecutter*,
-   building and distributing your package
-   is taken care of by `GitHub Actions`_
-   when you publish a `GitHub Release`_.
-   For more information,
-   see the section :ref:`The Release workflow`.
-
-This section gives a short overview of
-how you can build and distribute your package
-from the command line,
-using the following Poetry commands:
-
-.. code:: console
-
-   $ poetry build
-   $ poetry publish
-
-Building the package is done with the `python build`_ command,
-which generates *distribution packages*
-in the ``dist`` directory of your project.
-These are compressed archives that
-an end-user can download and install on their system.
-They come in two flavours:
-source (or *sdist*) archives, and
-binary packages in the wheel_ format.
-
-Publishing the package is done with the `python publish`_ command,
-which uploads the distribution packages
-to your account on PyPI_,
-the official Python package registry.
-
-.. _python build: https://python-poetry.org/docs/cli/#build
-.. _python publish: https://python-poetry.org/docs/cli/#publish
-.. _wheel: https://www.python.org/dev/peps/pep-0427/
-
-
-Installing the package
-----------------------
-
-Once your package is on PyPI,
-others can install it with pip_, pipx_, or Poetry:
-
-.. code:: console
-
-   $ pip install <project>
-   $ pipx install <project>
-   $ poetry add <project>
-
-While pip_ is the workhorse of the Python packaging ecosystem,
-you should use higher-level tools to install your package:
-
-- If the package is an application, install it with pipx_.
-- If the package is a library, install it with `poetry add`_ in other projects.
-
-The primary benefit of these installation methods is that
-your package is installed into an isolated environment,
-without polluting the system environment,
-or the environments of other applications.
-This way,
-applications can use specific versions of their direct and indirect dependencies,
-without getting in each other's way.
-
-.. _poetry add: https://python-poetry.org/docs/cli/#add
-
-If the other project is not managed by Poetry,
-use whatever package manager the other project uses.
-You can always install your project into a virtual environment with plain pip_.
-
-
-Dependencies
+Using Poetry
 ~~~~~~~~~~~~
-
-Dependencies are Python packages used by your project,
-and they come in two types:
-
-- *Core dependencies* are required by users running your code,
-  and typically consist of third-party libraries imported by your package.
-  When your package is distributed,
-  the package metainfo includes these dependencies,
-  allowing tools like pip_ to automatically install them alongside your package.
-
-- *Development dependencies* are only required by developers working on your code.
-  Examples are applications used to run tests,
-  check code for style and correctness,
-  or to build documentation.
-  These dependencies are not a part of distribution packages,
-  because users do not require them to run your code.
-
 
 .. _Managing dependencies:
 
@@ -719,77 +625,6 @@ in the ``pyproject.toml`` file.
    Dependencies in the *Hypermodern Python Cookiecutter* are managed by :ref:`Dependabot <Dependabot integration>`.
    When newer versions of dependencies become available,
    Dependabot updates the ``pyproject.toml`` and ``poetry.lock`` files and submits a pull request.
-
-
-Version constraints
--------------------
-
-`Version constraints <Versions and constraints_>`_ express
-which versions of dependencies are compatible with your project.
-In the case of core dependencies,
-they are also a part of distribution packages,
-and as such affect end-users of your package.
-
-For every dependency added to your project,
-Poetry writes a version constraint to ``pyproject.toml``.
-Dependencies are kept in two TOML tables:
-
-- ``tool.poetry.dependencies``---for core dependencies
-- ``tool.poetry.dev-dependencies``---for development dependencies
-
-By default, version constraints require users to have at least
-the version that was current when the dependency was added to the project.
-Users can also upgrade to newer releases of dependencies,
-as long as the version number does not indicate a breaking change.
-(According to the `Semantic Versioning`_ standard,
-only major releases may contain breaking changes,
-once a project has reached version 1.0.0.)
-
-.. _Versions and constraints: https://python-poetry.org/docs/versions/
-.. _Semantic Versioning: https://semver.org/
-
-
-.. _The lock file:
-
-The lock file
--------------
-
-Poetry records the exact version of each direct and indirect dependency
-in its lock file, named ``poetry.lock`` and located in the root directory of the project.
-The lock file does not affect users of the package,
-because its contents are not included in distribution packages.
-
-The lock file is useful for a number of reasons:
-
-- It ensures that local checks run in the same environment as on the CI server,
-  making the CI predictable and deterministic.
-- When collaborating with other developers,
-  it allows everybody to use the same development environment.
-- When deploying an application, the lock file helps you
-  keep production and development environments as similar as possible
-  (`dev-prod parity`_).
-
-.. _dev-prod parity: https://12factor.net/dev-prod-parity
-
-For these reasons, the lock file should be kept under source control.
-
-
-The Poetry environment
-~~~~~~~~~~~~~~~~~~~~~~
-
-Poetry manages a `virtual environment`_ for your project,
-which contains your package, its core dependencies, and the development dependencies.
-All dependencies are kept at the versions specified by the lock file.
-
-A virtual environment gives your project
-an isolated runtime environment,
-consisting of a specific Python version and
-an independent set of installed Python packages.
-This way, the dependencies of your current project
-do not interfere with the system-wide Python installation,
-or other projects you're working on.
-
-.. _virtual environment: https://docs.python.org/3/tutorial/venv.html
 
 
 Installing the package for development
@@ -889,6 +724,171 @@ You can also run developer tools, such as pytest_:
 While it is handy to have developer tools available in the Poetry environment,
 it is usually recommended to run these using Nox,
 as described in the next section.
+
+
+Building and distributing the package
+-------------------------------------
+
+.. note::
+
+   With the *Hypermodern Python Cookiecutter*,
+   building and distributing your package
+   is taken care of by `GitHub Actions`_
+   when you publish a `GitHub Release`_.
+   For more information,
+   see the section :ref:`The Release workflow`.
+
+This section gives a short overview of
+how you can build and distribute your package
+from the command line,
+using the following Poetry commands:
+
+.. code:: console
+
+   $ poetry build
+   $ poetry publish
+
+Building the package is done with the `python build`_ command,
+which generates *distribution packages*
+in the ``dist`` directory of your project.
+These are compressed archives that
+an end-user can download and install on their system.
+They come in two flavours:
+source (or *sdist*) archives, and
+binary packages in the wheel_ format.
+
+Publishing the package is done with the `python publish`_ command,
+which uploads the distribution packages
+to your account on PyPI_,
+the official Python package registry.
+
+.. _python build: https://python-poetry.org/docs/cli/#build
+.. _python publish: https://python-poetry.org/docs/cli/#publish
+.. _wheel: https://www.python.org/dev/peps/pep-0427/
+
+
+Installing the package
+----------------------
+
+Once your package is on PyPI,
+others can install it with pip_, pipx_, or Poetry:
+
+.. code:: console
+
+   $ pip install <project>
+   $ pipx install <project>
+   $ poetry add <project>
+
+While pip_ is the workhorse of the Python packaging ecosystem,
+you should use higher-level tools to install your package:
+
+- If the package is an application, install it with pipx_.
+- If the package is a library, install it with `poetry add`_ in other projects.
+
+The primary benefit of these installation methods is that
+your package is installed into an isolated environment,
+without polluting the system environment,
+or the environments of other applications.
+This way,
+applications can use specific versions of their direct and indirect dependencies,
+without getting in each other's way.
+
+.. _poetry add: https://python-poetry.org/docs/cli/#add
+
+If the other project is not managed by Poetry,
+use whatever package manager the other project uses.
+You can always install your project into a virtual environment with plain pip_.
+
+
+Dependencies
+~~~~~~~~~~~~
+
+Dependencies are Python packages used by your project,
+and they come in two types:
+
+- *Core dependencies* are required by users running your code,
+  and typically consist of third-party libraries imported by your package.
+  When your package is distributed,
+  the package metainfo includes these dependencies,
+  allowing tools like pip_ to automatically install them alongside your package.
+
+- *Development dependencies* are only required by developers working on your code.
+  Examples are applications used to run tests,
+  check code for style and correctness,
+  or to build documentation.
+  These dependencies are not a part of distribution packages,
+  because users do not require them to run your code.
+
+
+Version constraints
+-------------------
+
+`Version constraints <Versions and constraints_>`_ express
+which versions of dependencies are compatible with your project.
+In the case of core dependencies,
+they are also a part of distribution packages,
+and as such affect end-users of your package.
+
+For every dependency added to your project,
+Poetry writes a version constraint to ``pyproject.toml``.
+Dependencies are kept in two TOML tables:
+
+- ``tool.poetry.dependencies``---for core dependencies
+- ``tool.poetry.dev-dependencies``---for development dependencies
+
+By default, version constraints require users to have at least
+the version that was current when the dependency was added to the project.
+Users can also upgrade to newer releases of dependencies,
+as long as the version number does not indicate a breaking change.
+(According to the `Semantic Versioning`_ standard,
+only major releases may contain breaking changes,
+once a project has reached version 1.0.0.)
+
+.. _Versions and constraints: https://python-poetry.org/docs/versions/
+.. _Semantic Versioning: https://semver.org/
+
+
+.. _The lock file:
+
+The lock file
+-------------
+
+Poetry records the exact version of each direct and indirect dependency
+in its lock file, named ``poetry.lock`` and located in the root directory of the project.
+The lock file does not affect users of the package,
+because its contents are not included in distribution packages.
+
+The lock file is useful for a number of reasons:
+
+- It ensures that local checks run in the same environment as on the CI server,
+  making the CI predictable and deterministic.
+- When collaborating with other developers,
+  it allows everybody to use the same development environment.
+- When deploying an application, the lock file helps you
+  keep production and development environments as similar as possible
+  (`dev-prod parity`_).
+
+.. _dev-prod parity: https://12factor.net/dev-prod-parity
+
+For these reasons, the lock file should be kept under source control.
+
+
+The Poetry environment
+~~~~~~~~~~~~~~~~~~~~~~
+
+Poetry manages a `virtual environment`_ for your project,
+which contains your package, its core dependencies, and the development dependencies.
+All dependencies are kept at the versions specified by the lock file.
+
+A virtual environment gives your project
+an isolated runtime environment,
+consisting of a specific Python version and
+an independent set of installed Python packages.
+This way, the dependencies of your current project
+do not interfere with the system-wide Python installation,
+or other projects you're working on.
+
+.. _virtual environment: https://docs.python.org/3/tutorial/venv.html
 
 
 .. _Using Nox:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1357,10 +1357,6 @@ for details about the configuration file.
 
 __ https://pre-commit.com/#adding-pre-commit-plugins-to-your-project
 
-
-Available hooks
----------------
-
 The *Hypermodern Python Cookiecutter* comes with
 a pre-commit configuration
 consisting of the following hooks:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1966,50 +1966,6 @@ only direct dependencies are included.
    don't forget to update the requirements file as well.
 
 
-Continuous integration using GitHub Actions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Secrets
--------
-
-Some workflows use tokens to access external services.
-The following table lists the required tokens,
-which need to be stored as secrets in the repository settings on GitHub:
-
-.. table:: Secrets
-   :class: hypermodern-table
-   :widths: auto
-
-   =================== ===================
-   ``PYPI_TOKEN``      PyPI_ API token
-   ``TEST_PYPI_TOKEN`` TestPyPI_ API token
-   =================== ===================
-
-You can generate these API tokens
-from your account settings on PyPI_ and TestPyPI_.
-
-
-.. _Workflow constraints:
-
-Constraints file
-----------------
-
-GitHub Actions workflows install the following tools:
-
-- pip_
-- Poetry_
-- Nox_
-
-These dependencies are pinned using a `constraints file`_
-located in ``.github/workflow/constraints.txt``.
-
-.. note::
-
-   The constraints file is managed by :ref:`Dependabot <Dependabot integration>`.
-   When newer versions of the tools become available,
-   Dependabot updates the constraints file and submits a pull request.
-
-
 .. _GitHub Actions workflows:
 
 GitHub Actions workflows
@@ -2065,6 +2021,48 @@ the following workflows:
    GitHub Actions used by these workflows are managed by :ref:`Dependabot <Dependabot integration>`.
    When newer versions of GitHub Actions become available,
    Dependabot updates the workflows that use them and submits a pull request.
+
+
+Secrets
+-------
+
+Some workflows use tokens to access external services.
+The following table lists the required tokens,
+which need to be stored as secrets in the repository settings on GitHub:
+
+.. table:: Secrets
+   :class: hypermodern-table
+   :widths: auto
+
+   =================== ===================
+   ``PYPI_TOKEN``      PyPI_ API token
+   ``TEST_PYPI_TOKEN`` TestPyPI_ API token
+   =================== ===================
+
+You can generate these API tokens
+from your account settings on PyPI_ and TestPyPI_.
+
+
+.. _Workflow constraints:
+
+Constraints file
+----------------
+
+GitHub Actions workflows install the following tools:
+
+- pip_
+- Poetry_
+- Nox_
+
+These dependencies are pinned using a `constraints file`_
+located in ``.github/workflow/constraints.txt``.
+
+.. note::
+
+   The constraints file is managed by :ref:`Dependabot <Dependabot integration>`.
+   When newer versions of the tools become available,
+   Dependabot updates the constraints file and submits a pull request.
+
 
 .. _The Tests workflow:
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -550,6 +550,24 @@ for a detailed description of each configuration key.
 Dependencies
 ------------
 
+.. note::
+
+   Dependencies are Python packages used by your project,
+   and they come in two types:
+
+   - *Core dependencies* are required by users running your code,
+     and typically consist of third-party libraries imported by your package.
+     When your package is distributed,
+     the package metainfo includes these dependencies,
+     allowing tools like pip_ to automatically install them alongside your package.
+
+   - *Development dependencies* are only required by developers working on your code.
+     Examples are applications used to run tests,
+     check code for style and correctness,
+     or to build documentation.
+     These dependencies are not a part of distribution packages,
+     because users do not require them to run your code.
+
 This project template has a core dependency on Click_,
 a library for creating command-line interfaces.
 The template also comes with various development dependencies.
@@ -802,23 +820,6 @@ You can always install your project into a virtual environment with plain pip_.
 
 Dependencies
 ~~~~~~~~~~~~
-
-Dependencies are Python packages used by your project,
-and they come in two types:
-
-- *Core dependencies* are required by users running your code,
-  and typically consist of third-party libraries imported by your package.
-  When your package is distributed,
-  the package metainfo includes these dependencies,
-  allowing tools like pip_ to automatically install them alongside your package.
-
-- *Development dependencies* are only required by developers working on your code.
-  Examples are applications used to run tests,
-  check code for style and correctness,
-  or to build documentation.
-  These dependencies are not a part of distribution packages,
-  because users do not require them to run your code.
-
 
 Version constraints
 -------------------

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -927,268 +927,6 @@ For example, the following may be more practical during development
 .. _--reuse-existing-virtualenvs: https://nox.thea.codes/en/stable/usage.html#re-using-virtualenvs
 
 
-Available sessions
-------------------
-
-.. _Table of Nox sessions:
-
-The following table gives an overview of the available Nox sessions:
-
-.. table:: Nox sessions
-   :class: hypermodern-table
-   :widths: auto
-
-   ========================================== ============================== ================== =========
-   Session                                    Description                    Python              Default
-   ========================================== ============================== ================== =========
-   :ref:`docs <The docs session>`             Build Sphinx_ documentation    ``3.8``
-   :ref:`mypy <The mypy session>`             Type-check with mypy_          ``3.6`` … ``3.8``      ✓
-   :ref:`pre-commit <The pre-commit session>` Lint with pre-commit_          ``3.6`` … ``3.8``      ✓
-   :ref:`safety <The safety session>`         Scan dependencies with Safety_ ``3.8``                ✓
-   :ref:`tests <The tests session>`           Run tests with pytest_         ``3.6`` … ``3.8``      ✓
-   :ref:`typeguard <The typeguard session>`   Type-check with Typeguard_     ``3.6`` … ``3.8``
-   :ref:`xdoctest <The xdoctest session>`     Run examples with xdoctest_    ``3.6`` … ``3.8``
-   ========================================== ============================== ================== =========
-
-
-.. _The docs session:
-
-The docs session
-................
-
-Build the documentation using the Nox session ``docs``:
-
-.. code:: console
-
-   $ nox --session=docs
-
-The docs session runs the command ``sphinx-build``
-to generate the HTML documentation from the Sphinx directory.
-
-In `interactive mode`__---such
-as when invoking Nox from a terminal---sphinx-autobuild_ is used instead.
-This tool has several advantages
-when you are editing the documentation files:
-
-__ https://nox.thea.codes/en/stable/usage.html#forcing-non-interactive-behavior
-
-- It rebuilds the documentation whenever a change is detected.
-- It spins up a web server with live reloading.
-- It opens the location of the web server in your browser.
-
-.. _sphinx-autobuild: https://github.com/GaretJax/sphinx-autobuild
-
-Use the ``--`` separator to pass additional options to either tool.
-For example, to treat warnings as errors and run in nit-picky mode:
-
-.. code:: console
-
-   $ nox --session=docs -- -W -n docs docs/_build
-
-This Nox session always runs with the current major release of Python.
-
-
-.. _The mypy session:
-
-The mypy session
-................
-
-mypy_ is the pioneer and *de facto* reference implementation of static type checking in Python.
-Learn more about it in the section :ref:`Type-checking with mypy`.
-
-Run mypy using Nox:
-
-.. code:: console
-
-   $ nox --session=mypy
-
-You can also run the type checker with a specific Python version.
-For example, the following command runs mypy
-using the current stable release of Python:
-
-.. code:: console
-
-   $ nox --session=mypy-3.8
-
-Use the separator ``--`` to pass additional options and arguments to ``mypy``.
-For example, the following command type-checks only the ``__main__`` module:
-
-.. code:: console
-
-   $ nox --session=mypy -- src/<package>/__main__.py
-
-
-.. _The pre-commit session:
-
-The pre-commit session
-......................
-
-pre-commit_ is a multi-language linter framework and a Git hook manager.
-Learn more about it in the section :ref:`Linting with pre-commit`.
-
-Run pre-commit from Nox using the ``pre-commit`` session:
-
-.. code:: console
-
-   $ nox --session=pre-commit
-
-This session always runs with the current stable release of Python.
-
-Use the separator ``--`` to pass additional options to ``pre-commit``.
-For example, the following command installs the pre-commit hooks,
-so they run automatically on every commit you make:
-
-.. code:: console
-
-   $ nox --session=pre-commit -- install
-
-
-.. _The safety session:
-
-The safety session
-..................
-
-Safety_ checks the dependencies of your project for known security vulnerabilities,
-using a curated database of insecure Python packages.
-The *Hypermodern Python Cookiecutter* uses the `poetry export`_ command
-to convert Poetry's lock file to a `requirements file`_,
-for consumption by Safety.
-
-.. _poetry export: https://python-poetry.org/docs/cli/#export
-.. _requirements file: https://pip.readthedocs.io/en/stable/user_guide/#requirements-files
-
-Run Safety_ using the ``safety`` session:
-
-.. code:: console
-
-   $ nox --session=safety
-
-This session always runs with the current stable release of Python.
-
-
-.. _The tests session:
-
-The tests session
-.................
-
-Tests are written using the pytest_ testing framework.
-Learn more about it in the section :ref:`Testing with pytest`.
-
-Run the test suite using the Nox session ``tests``:
-
-.. code:: console
-
-   $ nox --session=tests
-
-The tests session runs the test suite against the installed code.
-More specifically, the session builds a wheel from your project and
-installs it into the Nox environment,
-with dependencies pinned as specified by Poetry's lock file.
-
-You can also run the test suite with a specific Python version.
-For example, the following command runs the test suite
-using the current stable release of Python:
-
-.. code:: console
-
-   $ nox --session=tests-3.8
-
-Use the separator ``--`` to pass additional options to ``pytest``.
-For example, the following command runs only the test case ``test_main_succeeds``:
-
-.. code:: console
-
-   $ nox --session=tests -- -k test_main_succeeds
-
-
-.. _The typeguard session:
-
-The typeguard session
-.....................
-
-Typeguard_ is a runtime type checker and pytest_ plugin.
-It can type-check function calls during test runs via an `import hook`__.
-
-__ https://docs.python.org/3/reference/import.html#import-hooks
-
-Typeguard checks that arguments passed to functions
-match the type annotations of the function parameters,
-and that the return value provided by the function
-matches the return type annotation.
-In the case of generator functions,
-Typeguard checks the yields, sends and the return value
-against the ``Generator`` annotation.
-
-Run Typeguard_ using Nox:
-
-.. code:: console
-
-   $ nox --session=typeguard
-
-The typeguard session runs the test suite with runtime type-checking enabled.
-It is similar to the :ref:`tests session <The tests session>`,
-with the difference that your package is instrumented by Typeguard.
-
-You can run the session with a specific Python version.
-For example, the following command runs the session
-with the current stable release of Python:
-
-.. code:: console
-
-   $ nox --session=typeguard-3.8
-
-Use the separator ``--`` to pass additional options and arguments to pytest.
-For example, the following command runs only tests for the ``__main__`` module:
-
-.. code:: console
-
-   $ nox --session=typeguard -- tests/test_main.py
-
-.. note::
-
-   Typeguard generates a warning about missing type annotations for a Click object.
-   This is due to the fact that ``__main__.main`` is wrapped by a decorator,
-   and its type annotations only apply to the inner function,
-   not the resulting object as seen by the test suite.
-
-
-.. _The xdoctest session:
-
-The xdoctest session
-....................
-
-The xdoctest_ tool
-runs examples in your docstrings and
-compares the actual output to the expected output as per the docstring.
-This serves multiple purposes:
-
-- The example is checked for correctness.
-- You ensure that the documentation is up-to-date.
-- Your codebase gets additional test coverage for free.
-
-Run the tool using the Nox session ``xdoctest``:
-
-.. code:: console
-
-   $ nox --session=xdoctest
-
-You can also run the test suite with a specific Python version.
-For example, the following command runs the examples
-using the current stable release of Python:
-
-.. code:: console
-
-   $ nox --session=xdoctest-3.8
-
-By default, the Nox session uses the ``all`` subcommand to run all examples.
-You can also list examples using the ``list`` subcommand,
-or run specific examples:
-
-.. code:: console
-
-   $ nox --session=xdoctest -- list
-
-
 Using Poetry inside Nox sessions
 --------------------------------
 
@@ -1256,6 +994,268 @@ The helper class has the following methods:
 
 ``noxfile.Poetry.version(self)``
    Return the package version.
+
+
+Nox sessions
+~~~~~~~~~~~~
+
+.. _Table of Nox sessions:
+
+The following table gives an overview of the available Nox sessions:
+
+.. table:: Nox sessions
+   :class: hypermodern-table
+   :widths: auto
+
+   ========================================== ============================== ================== =========
+   Session                                    Description                    Python              Default
+   ========================================== ============================== ================== =========
+   :ref:`docs <The docs session>`             Build Sphinx_ documentation    ``3.8``
+   :ref:`mypy <The mypy session>`             Type-check with mypy_          ``3.6`` … ``3.8``      ✓
+   :ref:`pre-commit <The pre-commit session>` Lint with pre-commit_          ``3.6`` … ``3.8``      ✓
+   :ref:`safety <The safety session>`         Scan dependencies with Safety_ ``3.8``                ✓
+   :ref:`tests <The tests session>`           Run tests with pytest_         ``3.6`` … ``3.8``      ✓
+   :ref:`typeguard <The typeguard session>`   Type-check with Typeguard_     ``3.6`` … ``3.8``
+   :ref:`xdoctest <The xdoctest session>`     Run examples with xdoctest_    ``3.6`` … ``3.8``
+   ========================================== ============================== ================== =========
+
+
+.. _The docs session:
+
+The docs session
+----------------
+
+Build the documentation using the Nox session ``docs``:
+
+.. code:: console
+
+   $ nox --session=docs
+
+The docs session runs the command ``sphinx-build``
+to generate the HTML documentation from the Sphinx directory.
+
+In `interactive mode`__---such
+as when invoking Nox from a terminal---sphinx-autobuild_ is used instead.
+This tool has several advantages
+when you are editing the documentation files:
+
+__ https://nox.thea.codes/en/stable/usage.html#forcing-non-interactive-behavior
+
+- It rebuilds the documentation whenever a change is detected.
+- It spins up a web server with live reloading.
+- It opens the location of the web server in your browser.
+
+.. _sphinx-autobuild: https://github.com/GaretJax/sphinx-autobuild
+
+Use the ``--`` separator to pass additional options to either tool.
+For example, to treat warnings as errors and run in nit-picky mode:
+
+.. code:: console
+
+   $ nox --session=docs -- -W -n docs docs/_build
+
+This Nox session always runs with the current major release of Python.
+
+
+.. _The mypy session:
+
+The mypy session
+----------------
+
+mypy_ is the pioneer and *de facto* reference implementation of static type checking in Python.
+Learn more about it in the section :ref:`Type-checking with mypy`.
+
+Run mypy using Nox:
+
+.. code:: console
+
+   $ nox --session=mypy
+
+You can also run the type checker with a specific Python version.
+For example, the following command runs mypy
+using the current stable release of Python:
+
+.. code:: console
+
+   $ nox --session=mypy-3.8
+
+Use the separator ``--`` to pass additional options and arguments to ``mypy``.
+For example, the following command type-checks only the ``__main__`` module:
+
+.. code:: console
+
+   $ nox --session=mypy -- src/<package>/__main__.py
+
+
+.. _The pre-commit session:
+
+The pre-commit session
+----------------------
+
+pre-commit_ is a multi-language linter framework and a Git hook manager.
+Learn more about it in the section :ref:`Linting with pre-commit`.
+
+Run pre-commit from Nox using the ``pre-commit`` session:
+
+.. code:: console
+
+   $ nox --session=pre-commit
+
+This session always runs with the current stable release of Python.
+
+Use the separator ``--`` to pass additional options to ``pre-commit``.
+For example, the following command installs the pre-commit hooks,
+so they run automatically on every commit you make:
+
+.. code:: console
+
+   $ nox --session=pre-commit -- install
+
+
+.. _The safety session:
+
+The safety session
+------------------
+
+Safety_ checks the dependencies of your project for known security vulnerabilities,
+using a curated database of insecure Python packages.
+The *Hypermodern Python Cookiecutter* uses the `poetry export`_ command
+to convert Poetry's lock file to a `requirements file`_,
+for consumption by Safety.
+
+.. _poetry export: https://python-poetry.org/docs/cli/#export
+.. _requirements file: https://pip.readthedocs.io/en/stable/user_guide/#requirements-files
+
+Run Safety_ using the ``safety`` session:
+
+.. code:: console
+
+   $ nox --session=safety
+
+This session always runs with the current stable release of Python.
+
+
+.. _The tests session:
+
+The tests session
+-----------------
+
+Tests are written using the pytest_ testing framework.
+Learn more about it in the section :ref:`Testing with pytest`.
+
+Run the test suite using the Nox session ``tests``:
+
+.. code:: console
+
+   $ nox --session=tests
+
+The tests session runs the test suite against the installed code.
+More specifically, the session builds a wheel from your project and
+installs it into the Nox environment,
+with dependencies pinned as specified by Poetry's lock file.
+
+You can also run the test suite with a specific Python version.
+For example, the following command runs the test suite
+using the current stable release of Python:
+
+.. code:: console
+
+   $ nox --session=tests-3.8
+
+Use the separator ``--`` to pass additional options to ``pytest``.
+For example, the following command runs only the test case ``test_main_succeeds``:
+
+.. code:: console
+
+   $ nox --session=tests -- -k test_main_succeeds
+
+
+.. _The typeguard session:
+
+The typeguard session
+---------------------
+
+Typeguard_ is a runtime type checker and pytest_ plugin.
+It can type-check function calls during test runs via an `import hook`__.
+
+__ https://docs.python.org/3/reference/import.html#import-hooks
+
+Typeguard checks that arguments passed to functions
+match the type annotations of the function parameters,
+and that the return value provided by the function
+matches the return type annotation.
+In the case of generator functions,
+Typeguard checks the yields, sends and the return value
+against the ``Generator`` annotation.
+
+Run Typeguard_ using Nox:
+
+.. code:: console
+
+   $ nox --session=typeguard
+
+The typeguard session runs the test suite with runtime type-checking enabled.
+It is similar to the :ref:`tests session <The tests session>`,
+with the difference that your package is instrumented by Typeguard.
+
+You can run the session with a specific Python version.
+For example, the following command runs the session
+with the current stable release of Python:
+
+.. code:: console
+
+   $ nox --session=typeguard-3.8
+
+Use the separator ``--`` to pass additional options and arguments to pytest.
+For example, the following command runs only tests for the ``__main__`` module:
+
+.. code:: console
+
+   $ nox --session=typeguard -- tests/test_main.py
+
+.. note::
+
+   Typeguard generates a warning about missing type annotations for a Click object.
+   This is due to the fact that ``__main__.main`` is wrapped by a decorator,
+   and its type annotations only apply to the inner function,
+   not the resulting object as seen by the test suite.
+
+
+.. _The xdoctest session:
+
+The xdoctest session
+--------------------
+
+The xdoctest_ tool
+runs examples in your docstrings and
+compares the actual output to the expected output as per the docstring.
+This serves multiple purposes:
+
+- The example is checked for correctness.
+- You ensure that the documentation is up-to-date.
+- Your codebase gets additional test coverage for free.
+
+Run the tool using the Nox session ``xdoctest``:
+
+.. code:: console
+
+   $ nox --session=xdoctest
+
+You can also run the test suite with a specific Python version.
+For example, the following command runs the examples
+using the current stable release of Python:
+
+.. code:: console
+
+   $ nox --session=xdoctest-3.8
+
+By default, the Nox session uses the ``all`` subcommand to run all examples.
+You can also list examples using the ``list`` subcommand,
+or run specific examples:
+
+.. code:: console
+
+   $ nox --session=xdoctest -- list
 
 
 .. _Testing with pytest:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1478,10 +1478,8 @@ and the *Hypermodern Python Cookiecutter* uses none of them.
 The Flake8 hook
 ---------------
 
-Flake8_ is a linter framework for Python.
-The configuration file for Flake8 and its extensions
-is named ``.flake8`` and located in the project directory.
-For more details, see the section :ref:`Flake8 plugins`.
+Flake8_ is an extensible linter framework for Python.
+For more details, see the section :ref:`Linting with Flake8`.
 
 
 The reorder-python-imports hook
@@ -1504,12 +1502,29 @@ from the pre-commit-hooks_ repository.
 .. _pre-commit-hooks: https://github.com/pre-commit/pre-commit-hooks
 
 
-.. _Flake8 plugins:
+.. _Linting with Flake8:
 
-Flake8 plugins
-~~~~~~~~~~~~~~
+Linting with Flake8
+~~~~~~~~~~~~~~~~~~~
 
-Flake8_ comes with a rich ecosystem of plugins.
+Flake8_ is an extensible linter framework for Python,
+and a command-line utility to run the linters on your source code.
+
+The configuration file for Flake8 and its extensions
+is named ``.flake8`` and located in the project directory.
+For details about the configuration file, see the `official reference`__.
+
+__ https://flake8.pycqa.org/en/latest/user/configuration.html
+
+The sections below describe the linters in more detail.
+Each section also notes any configuration settings applied by
+the *Hypermodern Python Cookiecutter*.
+
+
+Plugin overview
+---------------
+
+Flake8 comes with a rich ecosystem of plugins.
 The following table lists the Flake8 plugins used by
 the *Hypermodern Python Cookiecutter*,
 and links to their lists of error codes.
@@ -1529,11 +1544,6 @@ and links to their lists of error codes.
    darglint_                        Detect inaccurate docstrings                  `DAR <darglint codes_>`__
    Bandit_ / flake8-bandit_         Detect common security issues                 `S <Bandit codes_>`__
    ================================ ============================================= ======================================
-
-
-The following sections describe the linters in more detail.
-Each section also notes any configuration settings applied by
-the *Hypermodern Python Cookiecutter*.
 
 
 pyflakes

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1830,7 +1830,7 @@ The following options are enabled for enhanced output:
 External services
 ~~~~~~~~~~~~~~~~~
 
-Your repository can be integrated with several external services
+Your GitHub repository can be integrated with several external services
 for continuous integration and delivery.
 This section describes these external services,
 what they do, and how to set them up for your repository.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -300,7 +300,7 @@ For more details on these files, refer to the section :ref:`The initial package`
    ===================================== ===============================
 
 The test suite is located in the ``tests`` directory.
-For more details on these files, refer to the section :ref:`The test suite`.
+For more details on these files, refer to the section :ref:`Testing with pytest`.
 
 .. table:: Test suite
    :class: hypermodern-table
@@ -1266,12 +1266,6 @@ Testing with pytest
 
 Tests are written using the pytest_ testing framework,
 the *de facto* standard for testing in Python.
-
-
-.. _The test suite:
-
-The test suite
---------------
 
 The test suite is located in the ``tests`` directory::
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -701,6 +701,22 @@ in the ``pyproject.toml`` file.
 Installing the package for development
 --------------------------------------
 
+.. note::
+
+   Poetry manages a `virtual environment`_ for your project,
+   which contains your package, its core dependencies, and the development dependencies.
+   All dependencies are kept at the versions specified by the lock file.
+
+   .. _virtual environment: https://docs.python.org/3/tutorial/venv.html
+
+   A virtual environment gives your project
+   an isolated runtime environment,
+   consisting of a specific Python version and
+   an independent set of installed Python packages.
+   This way, the dependencies of your current project
+   do not interfere with the system-wide Python installation,
+   or other projects you're working on.
+
 You can install your package and its dependencies
 into Poetry's virtual environment
 using the command `poetry install`_.
@@ -873,20 +889,6 @@ You can always install your project into a virtual environment with plain pip_.
 
 The Poetry environment
 ~~~~~~~~~~~~~~~~~~~~~~
-
-Poetry manages a `virtual environment`_ for your project,
-which contains your package, its core dependencies, and the development dependencies.
-All dependencies are kept at the versions specified by the lock file.
-
-A virtual environment gives your project
-an isolated runtime environment,
-consisting of a specific Python version and
-an independent set of installed Python packages.
-This way, the dependencies of your current project
-do not interfere with the system-wide Python installation,
-or other projects you're working on.
-
-.. _virtual environment: https://docs.python.org/3/tutorial/venv.html
 
 
 .. _Using Nox:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -375,7 +375,7 @@ hosted on :ref:`Read the Docs <Read the Docs integration>`.
    ``docs/reference.rst``                API reference
    ===================================== ===============================
 
-The ``.github/workflows`` directory contains the :ref:`GitHub Actions workflows <Available workflows>`:
+The ``.github/workflows`` directory contains the :ref:`GitHub Actions workflows <GitHub Actions workflows>`:
 
 .. table:: GitHub Actions workflows
    :class: hypermodern-table
@@ -1955,7 +1955,7 @@ It manages the following dependencies:
                        | ``poetry.lock``
    Python              ``docs/requirements.txt``             :ref:`Read the Docs <Read the Docs integration>`
    Python              ``.github/workflows/constraints.txt`` :ref:`Workflow constraints`
-   GitHub Action       ``.github/workflows/*.yml``           :ref:`Available workflows`
+   GitHub Action       ``.github/workflows/*.yml``           :ref:`GitHub Actions workflows`
    =================== ===================================== ================================================
 
 
@@ -2024,10 +2024,10 @@ located in ``.github/workflow/constraints.txt``.
    Dependabot updates the constraints file and submits a pull request.
 
 
-.. _Available workflows:
+.. _GitHub Actions workflows:
 
-Available workflows
--------------------
+GitHub Actions workflows
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 The *Hypermodern Python Cookiecutter* defines
 the following workflows:
@@ -2056,7 +2056,7 @@ the following workflows:
 .. _The Tests workflow:
 
 The Tests workflow
-..................
+------------------
 
 The Tests workflow executes the test suite using Nox.
 
@@ -2083,7 +2083,7 @@ The workflow is defined in ``.github/workflows/tests.yml``.
 .. _The Coverage workflow:
 
 The Coverage workflow
-.....................
+---------------------
 
 The Coverage workflow uploads coverage data to Codecov_.
 
@@ -2111,7 +2111,7 @@ It is defined in ``.github/workflows/coverage.yml``.
 .. _The Docs workflow:
 
 The Docs workflow
-.................
+-----------------
 
 The Docs workflow builds the Sphinx_ documentation
 using the :ref:`docs <The docs session>` Nox session,
@@ -2141,7 +2141,7 @@ It is defined in ``.github/workflows/docs.yml``.
 .. _The Release Drafter workflow:
 
 The Release Drafter workflow
-............................
+----------------------------
 
 The Release Drafter workflow maintains a draft for the next GitHub Release.
 
@@ -2164,7 +2164,7 @@ The configuration file is located in ``.github/release-drafter.yml``.
 .. _The Release workflow:
 
 The Release workflow
-....................
+--------------------
 
 The Release workflow publishes your package on PyPI_, the Python Package Index.
 
@@ -2182,7 +2182,7 @@ The workflow is defined in ``.github/workflows/release.yml``.
 .. _The TestPyPI workflow:
 
 The TestPyPI workflow
-.....................
+---------------------
 
 The TestPyPI workflow publishes your package on TestPyPI_,
 a test instance of the Python Package Index.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1794,46 +1794,6 @@ The ``requirements.txt`` file pins the build dependencies for the Sphinx documen
 This file is only used on :ref:`Read the Docs <Read the Docs integration>`.
 
 
-.. _Read the Docs integration:
-
-Read the Docs
--------------
-
-`Read the Docs`_ hosts documentation for countless open-source Python projects.
-The hosting service also takes care of rebuilding the documentation
-when you update your project.
-Users can browse documentation
-for every published version, as well as the latest development version.
-
-Sign up at Read the Docs,
-and import your GitHub repository, using the button *Import a Project*.
-Read the Docs automatically starts building your
-documentation. When the build has completed, your documentation will have a
-public URL like this:
-
-   *https://<project>.readthedocs.io/*
-
-The configuration file is named ``.readthedocs.yml`` in the project directory.
-The *Hypermodern Python Cookiecutter* configures Read the Docs
-to build and install the package with Poetry,
-using a so-called `PEP 517`_-build.
-
-Build dependencies for the documentation
-are installed using a `requirements file`_ located at ``docs/requirements.txt``.
-Read the Docs currently does not support
-installing development dependencies using Poetry's lock file.
-For the sake of brevity and maintainability,
-only direct dependencies are included.
-
-.. note::
-
-   The requirements file is managed by :ref:`Dependabot <Dependabot integration>`.
-   When newer versions of the build dependencies become available,
-   Dependabot updates the requirements file and submits a pull request.
-   When adding or removing Sphinx extensions using Poetry,
-   don't forget to update the requirements file as well.
-
-
 .. _External services:
 
 External services
@@ -1940,6 +1900,8 @@ It manages the following dependencies:
    =================== ===================================== ================================================
 
 
+.. _Read the Docs integration:
+
 Read the Docs
 -------------
 
@@ -1958,10 +1920,34 @@ Follow these steps to set up Read the Docs for your repository:
 
 __ https://docs.readthedocs.io/en/stable/webhooks.html
 
-The configuration is included in the repository,
+Read the Docs automatically starts building your documentation,
+and will continue to do so when you push to master or make a release.
+Your documentation now has a public URL like this:
+
+   *https://<project>.readthedocs.io/*
+
+The configuration for Read the Docs is included in the repository,
 in the file `.readthedocs.yml`__.
+The *Hypermodern Python Cookiecutter* configures Read the Docs
+to build and install the package with Poetry,
+using a so-called `PEP 517`_-build.
 
 __ https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+Build dependencies for the documentation
+are installed using a `requirements file`_ located at ``docs/requirements.txt``.
+Read the Docs currently does not support
+installing development dependencies using Poetry's lock file.
+For the sake of brevity and maintainability,
+only direct dependencies are included.
+
+.. note::
+
+   The requirements file is managed by :ref:`Dependabot <Dependabot integration>`.
+   When newer versions of the build dependencies become available,
+   Dependabot updates the requirements file and submits a pull request.
+   When adding or removing Sphinx extensions using Poetry,
+   don't forget to update the requirements file as well.
 
 
 Continuous integration using GitHub Actions

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -547,6 +547,59 @@ for a detailed description of each configuration key.
 .. _pyproject.toml: https://python-poetry.org/docs/pyproject/
 
 
+Version constraints
+-------------------
+
+`Version constraints <Versions and constraints_>`_ express
+which versions of dependencies are compatible with your project.
+In the case of core dependencies,
+they are also a part of distribution packages,
+and as such affect end-users of your package.
+
+For every dependency added to your project,
+Poetry writes a version constraint to ``pyproject.toml``.
+Dependencies are kept in two TOML tables:
+
+- ``tool.poetry.dependencies``---for core dependencies
+- ``tool.poetry.dev-dependencies``---for development dependencies
+
+By default, version constraints require users to have at least
+the version that was current when the dependency was added to the project.
+Users can also upgrade to newer releases of dependencies,
+as long as the version number does not indicate a breaking change.
+(According to the `Semantic Versioning`_ standard,
+only major releases may contain breaking changes,
+once a project has reached version 1.0.0.)
+
+.. _Versions and constraints: https://python-poetry.org/docs/versions/
+.. _Semantic Versioning: https://semver.org/
+
+
+.. _The lock file:
+
+The lock file
+-------------
+
+Poetry records the exact version of each direct and indirect dependency
+in its lock file, named ``poetry.lock`` and located in the root directory of the project.
+The lock file does not affect users of the package,
+because its contents are not included in distribution packages.
+
+The lock file is useful for a number of reasons:
+
+- It ensures that local checks run in the same environment as on the CI server,
+  making the CI predictable and deterministic.
+- When collaborating with other developers,
+  it allows everybody to use the same development environment.
+- When deploying an application, the lock file helps you
+  keep production and development environments as similar as possible
+  (`dev-prod parity`_).
+
+.. _dev-prod parity: https://12factor.net/dev-prod-parity
+
+For these reasons, the lock file should be kept under source control.
+
+
 Dependencies
 ------------
 
@@ -820,59 +873,6 @@ You can always install your project into a virtual environment with plain pip_.
 
 Dependencies
 ~~~~~~~~~~~~
-
-Version constraints
--------------------
-
-`Version constraints <Versions and constraints_>`_ express
-which versions of dependencies are compatible with your project.
-In the case of core dependencies,
-they are also a part of distribution packages,
-and as such affect end-users of your package.
-
-For every dependency added to your project,
-Poetry writes a version constraint to ``pyproject.toml``.
-Dependencies are kept in two TOML tables:
-
-- ``tool.poetry.dependencies``---for core dependencies
-- ``tool.poetry.dev-dependencies``---for development dependencies
-
-By default, version constraints require users to have at least
-the version that was current when the dependency was added to the project.
-Users can also upgrade to newer releases of dependencies,
-as long as the version number does not indicate a breaking change.
-(According to the `Semantic Versioning`_ standard,
-only major releases may contain breaking changes,
-once a project has reached version 1.0.0.)
-
-.. _Versions and constraints: https://python-poetry.org/docs/versions/
-.. _Semantic Versioning: https://semver.org/
-
-
-.. _The lock file:
-
-The lock file
--------------
-
-Poetry records the exact version of each direct and indirect dependency
-in its lock file, named ``poetry.lock`` and located in the root directory of the project.
-The lock file does not affect users of the package,
-because its contents are not included in distribution packages.
-
-The lock file is useful for a number of reasons:
-
-- It ensures that local checks run in the same environment as on the CI server,
-  making the CI predictable and deterministic.
-- When collaborating with other developers,
-  it allows everybody to use the same development environment.
-- When deploying an application, the lock file helps you
-  keep production and development environments as similar as possible
-  (`dev-prod parity`_).
-
-.. _dev-prod parity: https://12factor.net/dev-prod-parity
-
-For these reasons, the lock file should be kept under source control.
-
 
 The Poetry environment
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -791,21 +791,21 @@ in the ``pyproject.toml`` file.
 Installing the package for development
 --------------------------------------
 
+Poetry manages a virtual environment for your project,
+which contains your package, its core dependencies, and the development dependencies.
+All dependencies are kept at the versions specified by the lock file.
+
 .. note::
 
-   Poetry manages a `virtual environment`_ for your project,
-   which contains your package, its core dependencies, and the development dependencies.
-   All dependencies are kept at the versions specified by the lock file.
-
-   .. _virtual environment: https://docs.python.org/3/tutorial/venv.html
-
-   A virtual environment gives your project
+   A `virtual environment`_ gives your project
    an isolated runtime environment,
    consisting of a specific Python version and
    an independent set of installed Python packages.
    This way, the dependencies of your current project
    do not interfere with the system-wide Python installation,
    or other projects you're working on.
+
+   .. _virtual environment: https://docs.python.org/3/tutorial/venv.html
 
 You can install your package and its dependencies
 into Poetry's virtual environment

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -362,7 +362,7 @@ and links each file to a section with more details.
    ``.cookiecutter.json``                :ref:`Project variables <Creating a project>`
    ``.darglint``                         Configuration for :ref:`darglint <darglint integration>`
    ``.dependabot/config.yml``            Configuration for :ref:`Dependabot <Dependabot integration>`
-   ``.flake8``                           Configuration for :ref:`Flake8 <Flake8 plugins>`
+   ``.flake8``                           Configuration for :ref:`Flake8 <The Flake8 hook>`
    ``.gitattributes``                    `Git attributes <.gitattributes_>`__
    ``.gitignore``                        `Git ignore file <.gitignore_>`__
    ``.github/release-drafter.yml``       Configuration for :ref:`Release Drafter <The Release Drafter workflow>`
@@ -1378,6 +1378,54 @@ consisting of the following hooks:
 .. _end-of-file-fixer: https://github.com/pre-commit/pre-commit-hooks#end-of-file-fixer
 .. _reorder-python-imports: https://github.com/asottile/reorder_python_imports
 .. _trailing-whitespace: https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace
+
+
+The Black hook
+--------------
+
+Black_ is the uncompromising Python code formatter.
+One of its greatest features is its lack of configurability.
+Blackened code looks the same regardless of the project you're reading.
+
+
+The Prettier hook
+-----------------
+
+Prettier_ is an opinionated code formatter for many languages,
+including YAML, Markdown, and JavaScript.
+Like Black, it has few options,
+and the *Hypermodern Python Cookiecutter* uses none of them.
+
+
+.. _The Flake8 hook:
+
+The Flake8 hook
+---------------
+
+Flake8_ is a linter framework for Python.
+The configuration file for Flake8 and its extensions
+is named ``.flake8`` and located in the project directory.
+For more details, see the section :ref:`Flake8 plugins`.
+
+
+The reorder-python-imports hook
+-------------------------------
+
+reorder-python-imports_ sorts imports in your Python code.
+Imports are separated into three sections,
+as recommended by `PEP 8`_: standard library, third party, first party.
+The tool also splits ``from`` imports onto separate lines to avoid merge conflicts,
+and moves them after normal imports.
+Any duplicate imports are removed.
+
+
+Hooks from pre-commit-hooks
+---------------------------
+
+The pre-commit configuration also includes several smaller hooks
+from the pre-commit-hooks_ repository.
+
+.. _pre-commit-hooks: https://github.com/pre-commit/pre-commit-hooks
 
 
 .. _Flake8 plugins:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1828,33 +1828,8 @@ only direct dependencies are included.
    don't forget to update the requirements file as well.
 
 
-Continuous integration using GitHub Actions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The *Hypermodern Python Cookiecutter* uses `GitHub Actions`_
-to implement continuous integration and delivery.
-With GitHub Actions,
-you define so-called workflows
-using YAML_ files located in the ``.github/workflows`` directory.
-
-A *workflow* is an automated process
-consisting of one or many jobs,
-each of which executes a series of steps.
-Workflows are triggered by events,
-for example when a commit is pushed
-or when a release is published.
-You can learn more about
-the workflow language and its supported keywords
-in the `official reference`__.
-
-__ https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
-
-Real-time logs for workflow runs are available
-from the *Actions* tab in your GitHub repository.
-
-
-External Services
------------------
+External services
+~~~~~~~~~~~~~~~~~
 
 Your repository can be integrated with several external services
 for continuous integration and delivery.
@@ -1863,7 +1838,7 @@ what they do, and how to set them up for your repository.
 
 
 PyPI
-....
+----
 
 PyPI_ is the official Python Package Index.
 Uploading your package to PyPI allows others to
@@ -1882,7 +1857,7 @@ via the :ref:`Release workflow <The Release workflow>`.
 
 
 TestPyPI
-........
+--------
 
 TestPyPI_ is a test instance of the Python package registry.
 It allows you to check your release before uploading it to the real index.
@@ -1902,7 +1877,7 @@ via the :ref:`TestPyPI workflow <The TestPyPI workflow>`.
 .. _Codecov integration:
 
 Codecov
-.......
+-------
 
 Codecov_ is a reporting service for code coverage.
 
@@ -1924,7 +1899,7 @@ The :ref:`Coverage workflow <The Coverage workflow>` uploads the coverage data.
 .. _Dependabot integration:
 
 Dependabot
-..........
+----------
 
 Dependabot_ creates pull requests with automated dependency updates.
 
@@ -1958,7 +1933,7 @@ It manages the following dependencies:
 
 
 Read the Docs
-.............
+-------------
 
 `Read the Docs`_ automates the building, versioning, and hosting of documentation.
 
@@ -1979,6 +1954,31 @@ The configuration is included in the repository,
 in the file `.readthedocs.yml`__.
 
 __ https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+
+Continuous integration using GitHub Actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The *Hypermodern Python Cookiecutter* uses `GitHub Actions`_
+to implement continuous integration and delivery.
+With GitHub Actions,
+you define so-called workflows
+using YAML_ files located in the ``.github/workflows`` directory.
+
+A *workflow* is an automated process
+consisting of one or many jobs,
+each of which executes a series of steps.
+Workflows are triggered by events,
+for example when a commit is pushed
+or when a release is published.
+You can learn more about
+the workflow language and its supported keywords
+in the `official reference`__.
+
+__ https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+
+Real-time logs for workflow runs are available
+from the *Actions* tab in your GitHub repository.
 
 
 Secrets

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -517,9 +517,6 @@ a helper class for invoking the program from within tests.
 .. _click.testing.CliRunner: https://click.palletsprojects.com/en/7.x/testing/
 
 
-Packaging
-~~~~~~~~~
-
 .. _The pyproject.toml file:
 
 The pyproject.toml file
@@ -549,6 +546,9 @@ for a detailed description of each configuration key.
 
 .. _pyproject.toml: https://python-poetry.org/docs/pyproject/
 
+
+Packaging
+~~~~~~~~~
 
 Building and distributing the package
 -------------------------------------

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -633,53 +633,6 @@ for a detailed description of each configuration key.
 .. _pyproject.toml: https://python-poetry.org/docs/pyproject/
 
 
-Dependencies
-------------
-
-This project template has a core dependency on Click_,
-a library for creating command-line interfaces.
-The template also comes with various development dependencies.
-See the table below for an overview of the dependencies of generated projects:
-
-.. table:: Dependencies
-   :class: hypermodern-table
-   :widths: auto
-
-   ================= =====================================================
-   click_            Composable command line interface toolkit
-   coverage__        Code coverage measurement for Python
-   mypy_             Optional static typing for Python
-   pre-commit_       A framework for managing and maintaining multi-language pre-commit hooks
-   pytest_           Simple powerful testing with Python
-   pytest-cov_       Pytest plugin for measuring coverage
-   safety_           Checks installed dependencies for known vulnerabilities
-   sphinx_           Python documentation generator
-   sphinx-autobuild_ Watch a Sphinx directory and rebuild the documentation when a change is detected
-   typeguard_        Run-time type checker for Python
-   xdoctest_         A rewrite of the builtin doctest module
-   ================= =====================================================
-
-__ Coverage.py_
-
-.. note::
-
-   Dependencies are Python packages used by your project,
-   and they come in two types:
-
-   - *Core dependencies* are required by users running your code,
-     and typically consist of third-party libraries imported by your package.
-     When your package is distributed,
-     the package metainfo includes these dependencies,
-     allowing tools like pip_ to automatically install them alongside your package.
-
-   - *Development dependencies* are only required by developers working on your code.
-     Examples are applications used to run tests,
-     check code for style and correctness,
-     or to build documentation.
-     These dependencies are not a part of distribution packages,
-     because users do not require them to run your code.
-
-
 Version constraints
 -------------------
 
@@ -707,6 +660,24 @@ once a project has reached version 1.0.0.)
 .. _Versions and constraints: https://python-poetry.org/docs/versions/
 .. _Semantic Versioning: https://semver.org/
 
+.. note::
+
+   Dependencies are Python packages used by your project,
+   and they come in two types:
+
+   - *Core dependencies* are required by users running your code,
+     and typically consist of third-party libraries imported by your package.
+     When your package is distributed,
+     the package metainfo includes these dependencies,
+     allowing tools like pip_ to automatically install them alongside your package.
+
+   - *Development dependencies* are only required by developers working on your code.
+     Examples are applications used to run tests,
+     check code for style and correctness,
+     or to build documentation.
+     These dependencies are not a part of distribution packages,
+     because users do not require them to run your code.
+
 
 .. _The lock file:
 
@@ -731,6 +702,35 @@ The lock file is useful for a number of reasons:
 .. _dev-prod parity: https://12factor.net/dev-prod-parity
 
 For these reasons, the lock file should be kept under source control.
+
+
+Dependencies
+------------
+
+This project template has a core dependency on Click_,
+a library for creating command-line interfaces.
+The template also comes with various development dependencies.
+See the table below for an overview of the dependencies of generated projects:
+
+.. table:: Dependencies
+   :class: hypermodern-table
+   :widths: auto
+
+   ================= =====================================================
+   click_            Composable command line interface toolkit
+   coverage__        Code coverage measurement for Python
+   mypy_             Optional static typing for Python
+   pre-commit_       A framework for managing and maintaining multi-language pre-commit hooks
+   pytest_           Simple powerful testing with Python
+   pytest-cov_       Pytest plugin for measuring coverage
+   safety_           Checks installed dependencies for known vulnerabilities
+   sphinx_           Python documentation generator
+   sphinx-autobuild_ Watch a Sphinx directory and rebuild the documentation when a change is detected
+   typeguard_        Run-time type checker for Python
+   xdoctest_         A rewrite of the builtin doctest module
+   ================= =====================================================
+
+__ Coverage.py_
 
 
 Using Poetry

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -887,10 +887,6 @@ use whatever package manager the other project uses.
 You can always install your project into a virtual environment with plain pip_.
 
 
-The Poetry environment
-~~~~~~~~~~~~~~~~~~~~~~
-
-
 .. _Using Nox:
 
 Using Nox

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -593,9 +593,6 @@ You can always install your project into a virtual environment with plain pip_.
 Dependencies
 ~~~~~~~~~~~~
 
-Types of dependencies
----------------------
-
 Dependencies are Python packages used by your project,
 and they come in two types:
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1511,6 +1511,8 @@ Linting with Flake8
 
 Flake8_ is an extensible linter framework for Python,
 and a command-line utility to run the linters on your source code.
+The |HPC| integrates Flake8 via a pre-commit_ hook,
+see the section :ref:`The Flake8 hook`.
 
 The configuration file for Flake8 and its extensions
 is named ``.flake8`` and located in the project directory.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -622,6 +622,7 @@ specified in `PEP 517`_ and `518 <PEP 518_>`__:
 - The ``tool`` table contains sub-tables
   where tools can store configuration under their PyPI_ name.
   Poetry stores its configuration in the ``tool.poetry`` table.
+  Coverage.py_ stores its configuration in the ``tool.coverage`` table.
 
 The ``tool.poetry`` table
 contains the metadata for your package,

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1828,8 +1828,6 @@ only direct dependencies are included.
    don't forget to update the requirements file as well.
 
 
-.. _Continuous integration using GitHub Actions:
-
 Continuous integration using GitHub Actions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1045,8 +1045,8 @@ For example, the following may be more practical during development
 .. _--reuse-existing-virtualenvs: https://nox.thea.codes/en/stable/usage.html#re-using-virtualenvs
 
 
-Nox sessions
-------------
+Overview of Nox sessions
+------------------------
 
 .. _Table of Nox sessions:
 
@@ -1072,7 +1072,7 @@ The following table gives an overview of the available Nox sessions:
 .. _The docs session:
 
 The docs session
-................
+----------------
 
 Build the documentation using the Nox session ``docs``:
 
@@ -1109,7 +1109,7 @@ This Nox session always runs with the current major release of Python.
 .. _The mypy session:
 
 The mypy session
-................
+----------------
 
 mypy_ is the pioneer and *de facto* reference implementation of static type checking in Python.
 Learn more about it in the section :ref:`Type-checking with mypy`.
@@ -1139,7 +1139,7 @@ For example, the following command type-checks only the ``__main__`` module:
 .. _The pre-commit session:
 
 The pre-commit session
-......................
+----------------------
 
 pre-commit_ is a multi-language linter framework and a Git hook manager.
 Learn more about it in the section :ref:`Linting with pre-commit`.
@@ -1164,7 +1164,7 @@ so they run automatically on every commit you make:
 .. _The safety session:
 
 The safety session
-..................
+------------------
 
 Safety_ checks the dependencies of your project for known security vulnerabilities,
 using a curated database of insecure Python packages.
@@ -1187,7 +1187,7 @@ This session always runs with the current stable release of Python.
 .. _The tests session:
 
 The tests session
-.................
+-----------------
 
 Tests are written using the pytest_ testing framework.
 Learn more about it in the section :ref:`The test suite`.
@@ -1222,7 +1222,7 @@ For example, the following command runs only the test case ``test_main_succeeds`
 .. _The typeguard session:
 
 The typeguard session
-.....................
+---------------------
 
 Typeguard_ is a runtime type checker and pytest_ plugin.
 It can type-check function calls during test runs via an `import hook`__.
@@ -1273,7 +1273,7 @@ For example, the following command runs only tests for the ``__main__`` module:
 .. _The xdoctest session:
 
 The xdoctest session
-....................
+--------------------
 
 The xdoctest_ tool
 runs examples in your docstrings and

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -2038,6 +2038,10 @@ __ https://help.github.com/en/actions/automating-your-workflow-with-github-actio
    Real-time logs for workflow runs are available
    from the *Actions* tab in your GitHub repository.
 
+
+Overview of workflows
+---------------------
+
 The *Hypermodern Python Cookiecutter* defines
 the following workflows:
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -362,7 +362,7 @@ and links each file to a section with more details.
    ``.cookiecutter.json``                :ref:`Project variables <Creating a project>`
    ``.darglint``                         Configuration for :ref:`darglint <darglint integration>`
    ``.dependabot/config.yml``            Configuration for :ref:`Dependabot <Dependabot integration>`
-   ``.flake8``                           Configuration for :ref:`Flake8 <Linting with Flake8>`
+   ``.flake8``                           Configuration for :ref:`Flake8 <Flake8 plugins>`
    ``.gitattributes``                    `Git attributes <.gitattributes_>`__
    ``.gitignore``                        `Git ignore file <.gitignore_>`__
    ``.github/release-drafter.yml``       Configuration for :ref:`Release Drafter <The Release Drafter workflow>`
@@ -1380,18 +1380,12 @@ consisting of the following hooks:
 .. _trailing-whitespace: https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace
 
 
-.. _Linting with Flake8:
+.. _Flake8 plugins:
 
-Linting with Flake8
-~~~~~~~~~~~~~~~~~~~
+Flake8 plugins
+~~~~~~~~~~~~~~
 
-This project template comes with an extensive suite of linters,
-using the Flake8_ linter framework.
-
-The configuration file for Flake8 and its extensions
-is named ``.flake8`` and located in the project directory.
-
-Flake8 comes with a rich ecosystem of extensions.
+Flake8_ comes with a rich ecosystem of plugins.
 The following table lists the Flake8 plugins used by
 the *Hypermodern Python Cookiecutter*,
 and links to their lists of error codes.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -547,6 +547,35 @@ for a detailed description of each configuration key.
 .. _pyproject.toml: https://python-poetry.org/docs/pyproject/
 
 
+Dependencies
+------------
+
+This project template has a core dependency on Click_,
+a library for creating command-line interfaces.
+The template also comes with various development dependencies.
+See the table below for an overview of the dependencies of generated projects:
+
+.. table:: Dependencies
+   :class: hypermodern-table
+   :widths: auto
+
+   ================= =====================================================
+   click_            Composable command line interface toolkit
+   coverage__        Code coverage measurement for Python
+   mypy_             Optional static typing for Python
+   pre-commit_       A framework for managing and maintaining multi-language pre-commit hooks
+   pytest_           Simple powerful testing with Python
+   pytest-cov_       Pytest plugin for measuring coverage
+   safety_           Checks installed dependencies for known vulnerabilities
+   sphinx_           Python documentation generator
+   sphinx-autobuild_ Watch a Sphinx directory and rebuild the documentation when a change is detected
+   typeguard_        Run-time type checker for Python
+   xdoctest_         A rewrite of the builtin doctest module
+   ================= =====================================================
+
+__ Coverage.py_
+
+
 Packaging
 ~~~~~~~~~
 
@@ -643,34 +672,6 @@ and they come in two types:
   These dependencies are not a part of distribution packages,
   because users do not require them to run your code.
 
-
-Dependencies of generated projects
-----------------------------------
-
-This project template has a core dependency on Click_,
-a library for creating command-line interfaces.
-The template also comes with various development dependencies.
-See the table below for an overview of the dependencies of generated projects:
-
-.. table:: Dependencies
-   :class: hypermodern-table
-   :widths: auto
-
-   ================= =====================================================
-   click_            Composable command line interface toolkit
-   coverage__        Code coverage measurement for Python
-   mypy_             Optional static typing for Python
-   pre-commit_       A framework for managing and maintaining multi-language pre-commit hooks
-   pytest_           Simple powerful testing with Python
-   pytest-cov_       Pytest plugin for measuring coverage
-   safety_           Checks installed dependencies for known vulnerabilities
-   sphinx_           Python documentation generator
-   sphinx-autobuild_ Watch a Sphinx directory and rebuild the documentation when a change is detected
-   typeguard_        Run-time type checker for Python
-   xdoctest_         A rewrite of the builtin doctest module
-   ================= =====================================================
-
-__ Coverage.py_
 
 .. _Managing dependencies:
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1738,7 +1738,8 @@ Code coverage with Coverage.py
 the source code of your program is executed while running its test suite.
 The |HPC| requires full test coverage.
 
-Code coverage is measured using `Coverage.py`_.
+Code coverage is measured using `Coverage.py`_
+during the :ref:`tests session <The tests session>`.
 When the test suite completes,
 a detailed coverage report is printed to the terminal.
 If the total coverage is below 100%,
@@ -1749,6 +1750,11 @@ in the ``tool.coverage`` table.
 The configuration informs the tool about your package name and source tree layout.
 It also enables branch analysis and the display of line numbers for missing coverage,
 and specifies the target coverage percentage.
+
+During continuous integration, coverage data is uploaded to the Codecov_ reporting service.
+For details, see the sections about
+:ref:`Codecov <Codecov integration>` and
+:ref:`The Coverage workflow`.
 
 
 .. _Type-checking with mypy:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1046,75 +1046,6 @@ For example, the following may be more practical during development
 .. _--reuse-existing-virtualenvs: https://nox.thea.codes/en/stable/usage.html#re-using-virtualenvs
 
 
-Using Poetry inside Nox sessions
---------------------------------
-
-.. note::
-
-   This section provides some background information about
-   how this project template integrates Nox and Poetry.
-   You can safely skip this section.
-
-**TL;DR** When writing Nox sessions for your project,
-
-- use ``install(session, "pkg")`` instead of ``session.install("pkg")``
-- use ``install_package(session)`` instead of ``session.install(".")``
-
-Nox sessions can invoke Poetry like any other command,
-using the function `nox.sessions.Session.run`_.
-Integrating Nox and Poetry in a sane way requires additional work.
-For this purpose, ``noxfile.py`` contains some glue code
-in the form of the ``install`` and ``install_package`` functions:
-
-.. _nox.sessions.Session.run: https://nox.thea.codes/en/stable/config.html#nox.sessions.Session.run
-
-``noxfile.install(session, *args)``:
-   Install development dependencies into a Nox session using Poetry.
-
-   The ``noxfile.install`` function
-   installs development dependencies into a Nox session,
-   using the versions specified in Poetry's lock file.
-   This is done by exporting the lock file in ``requirements.txt`` format,
-   and passing it as a `constraints file`_ to pip.
-   The function arguments are the same as those for `nox.sessions.Session.install`_:
-   The first argument is the ``Session`` object,
-   and the remaining arguments are command-line arguments for `pip install`_,
-   typically just the package or packages to be installed.
-
-   .. _nox.sessions.Session.install: https://nox.thea.codes/en/stable/config.html#nox.sessions.Session.install
-   .. _constraints file: https://pip.pypa.io/en/stable/user_guide/#constraints-files
-   .. _pip install: https://pip.pypa.io/en/stable/reference/pip_install/
-
-``noxfile.install_package(session)``:
-   Install the package into a Nox session using Poetry.
-
-   The ``noxfile.install_package`` function
-   installs your package into a Nox session,
-   including the core dependencies as specified in Poetry's lock file.
-   This is done by building a wheel from the package,
-   and installing it using pip_.
-   Dependencies are installed in the same way as in the ``noxfile.install`` function,
-   i.e. using a constraints file.
-   Its only argument is the ``Session`` object from Nox.
-
-The functions are implemented using a ``Poetry`` helper class,
-which encapsulates invocations of the Poetry command-line interface.
-The helper class has the following methods:
-
-``noxfile.Poetry.__init__(self, session)``
-   Initialize ``self``.
-   Instances need a session object for running commands.
-
-``noxfile.Poetry.build(self, *args)``
-   Build the package.
-
-``noxfile.Poetry.export(self, *args)``
-   Export the lock file to requirements format.
-
-``noxfile.Poetry.version(self)``
-   Return the package version.
-
-
 Nox sessions
 ------------
 
@@ -1375,6 +1306,75 @@ or run specific examples:
 .. code:: console
 
    $ nox --session=xdoctest -- list
+
+
+Using Poetry inside Nox sessions
+--------------------------------
+
+.. note::
+
+   This section provides some background information about
+   how this project template integrates Nox and Poetry.
+   You can safely skip this section.
+
+**TL;DR** When writing Nox sessions for your project,
+
+- use ``install(session, "pkg")`` instead of ``session.install("pkg")``
+- use ``install_package(session)`` instead of ``session.install(".")``
+
+Nox sessions can invoke Poetry like any other command,
+using the function `nox.sessions.Session.run`_.
+Integrating Nox and Poetry in a sane way requires additional work.
+For this purpose, ``noxfile.py`` contains some glue code
+in the form of the ``install`` and ``install_package`` functions:
+
+.. _nox.sessions.Session.run: https://nox.thea.codes/en/stable/config.html#nox.sessions.Session.run
+
+``noxfile.install(session, *args)``:
+   Install development dependencies into a Nox session using Poetry.
+
+   The ``noxfile.install`` function
+   installs development dependencies into a Nox session,
+   using the versions specified in Poetry's lock file.
+   This is done by exporting the lock file in ``requirements.txt`` format,
+   and passing it as a `constraints file`_ to pip.
+   The function arguments are the same as those for `nox.sessions.Session.install`_:
+   The first argument is the ``Session`` object,
+   and the remaining arguments are command-line arguments for `pip install`_,
+   typically just the package or packages to be installed.
+
+   .. _nox.sessions.Session.install: https://nox.thea.codes/en/stable/config.html#nox.sessions.Session.install
+   .. _constraints file: https://pip.pypa.io/en/stable/user_guide/#constraints-files
+   .. _pip install: https://pip.pypa.io/en/stable/reference/pip_install/
+
+``noxfile.install_package(session)``:
+   Install the package into a Nox session using Poetry.
+
+   The ``noxfile.install_package`` function
+   installs your package into a Nox session,
+   including the core dependencies as specified in Poetry's lock file.
+   This is done by building a wheel from the package,
+   and installing it using pip_.
+   Dependencies are installed in the same way as in the ``noxfile.install`` function,
+   i.e. using a constraints file.
+   Its only argument is the ``Session`` object from Nox.
+
+The functions are implemented using a ``Poetry`` helper class,
+which encapsulates invocations of the Poetry command-line interface.
+The helper class has the following methods:
+
+``noxfile.Poetry.__init__(self, session)``
+   Initialize ``self``.
+   Instances need a session object for running commands.
+
+``noxfile.Poetry.build(self, *args)``
+   Build the package.
+
+``noxfile.Poetry.export(self, *args)``
+   Export the lock file to requirements format.
+
+``noxfile.Poetry.version(self)``
+   Return the package version.
 
 
 .. _Linting with pre-commit:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -418,7 +418,7 @@ and links each file to a section with more details.
    ``.readthedocs.yml``                  Configuration for :ref:`Read the Docs <Read the Docs integration>`
    ``codecov.yml``                       Configuration for :ref:`Codecov <Codecov integration>`
    ``docs/conf.py``                      Configuration for :ref:`Sphinx <Documentation>`
-   ``mypy.ini``                          Configuration for :ref:`mypy <Configuring mypy>`
+   ``mypy.ini``                          Configuration for :ref:`mypy <Type-checking with mypy>`
    ``noxfile.py``                        Configuration for :ref:`Nox <Using Nox>`
    ``pyproject.toml``                    :ref:`Python package <The pyproject.toml file>` configuration,
                                          and configuration for :ref:`Coverage.py <Code coverage with Coverage.py>`
@@ -1788,19 +1788,7 @@ Type-checking with mypy
    or command-line parsers.
 
 mypy_ is the pioneer and *de facto* reference implementation of static type checking in Python.
-
-
-Running mypy
-------------
-
-Run mypy via its Nox session.
-For details, see the section :ref:`The mypy session`.
-
-
-.. _Configuring mypy:
-
-Configuring mypy
-----------------
+Invoke mypy via Nox, as explained in the section :ref:`The mypy session`.
 
 Configure mypy using the ``mypy.ini`` configuration file in the project directory.
 For details about supported configuration options, see the `official reference`__.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1959,28 +1959,6 @@ __ https://docs.readthedocs.io/en/stable/config-file/v2.html
 Continuous integration using GitHub Actions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The *Hypermodern Python Cookiecutter* uses `GitHub Actions`_
-to implement continuous integration and delivery.
-With GitHub Actions,
-you define so-called workflows
-using YAML_ files located in the ``.github/workflows`` directory.
-
-A *workflow* is an automated process
-consisting of one or many jobs,
-each of which executes a series of steps.
-Workflows are triggered by events,
-for example when a commit is pushed
-or when a release is published.
-You can learn more about
-the workflow language and its supported keywords
-in the `official reference`__.
-
-__ https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
-
-Real-time logs for workflow runs are available
-from the *Actions* tab in your GitHub repository.
-
-
 Secrets
 -------
 
@@ -2026,6 +2004,29 @@ located in ``.github/workflow/constraints.txt``.
 
 GitHub Actions workflows
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
+The *Hypermodern Python Cookiecutter* uses `GitHub Actions`_
+to implement continuous integration and delivery.
+With GitHub Actions,
+you define so-called workflows
+using YAML_ files located in the ``.github/workflows`` directory.
+
+A *workflow* is an automated process
+consisting of one or many jobs,
+each of which executes a series of steps.
+Workflows are triggered by events,
+for example when a commit is pushed
+or when a release is published.
+You can learn more about
+the workflow language and its supported keywords
+in the `official reference`__.
+
+__ https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+
+.. note::
+
+   Real-time logs for workflow runs are available
+   from the *Actions* tab in your GitHub repository.
 
 The *Hypermodern Python Cookiecutter* defines
 the following workflows:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1316,8 +1316,6 @@ Linting with pre-commit
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 pre-commit_ is a multi-language linter framework and a Git hook manager.
-Linters analyze source code to flag
-programming errors, bugs, stylistic errors, and suspicious constructs.
 pre-commit allows you to
 integrate the best industry standard linters into your Git workflow,
 even when written in a language other than Python.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1293,28 +1293,6 @@ or run specific examples:
    $ nox --session=xdoctest -- list
 
 
-.. _Code coverage with Coverage.py:
-
-Code coverage with Coverage.py
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-*Test coverage* is a measure of the degree to which
-the source code of your program is executed while running its test suite.
-This project template requires full test coverage.
-
-Code coverage is measured using `Coverage.py`_.
-When the test suite completes,
-a detailed coverage report is printed to the terminal.
-If the total coverage is below 100%,
-the test session fails.
-
-Coverage.py is configured using the ``pyproject.toml`` configuration file,
-in the ``tool.coverage`` table.
-The configuration informs the tool about your package name and source tree layout.
-It also enables branch analysis and the display of line numbers for missing coverage,
-and specifies the target coverage percentage.
-
-
 .. _Linting with pre-commit:
 
 Linting with pre-commit
@@ -1646,6 +1624,28 @@ as pytest_ uses assertions to verify expectations in tests.
 
 .. _Bandit codes:
 __ https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
+
+
+.. _Code coverage with Coverage.py:
+
+Code coverage with Coverage.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*Test coverage* is a measure of the degree to which
+the source code of your program is executed while running its test suite.
+This project template requires full test coverage.
+
+Code coverage is measured using `Coverage.py`_.
+When the test suite completes,
+a detailed coverage report is printed to the terminal.
+If the total coverage is below 100%,
+the test session fails.
+
+Coverage.py is configured using the ``pyproject.toml`` configuration file,
+in the ``tool.coverage`` table.
+The configuration informs the tool about your package name and source tree layout.
+It also enables branch analysis and the display of line numbers for missing coverage,
+and specifies the target coverage percentage.
 
 
 .. _Type-checking with mypy:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -871,9 +871,6 @@ use whatever package manager the other project uses.
 You can always install your project into a virtual environment with plain pip_.
 
 
-Dependencies
-~~~~~~~~~~~~
-
 The Poetry environment
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1400,19 +1400,17 @@ and links to their lists of error codes.
    :class: hypermodern-table
    :widths: auto
 
-   ======================= ============================================================== ======================================
-   Tool                    Description                                                    Code
-   ======================= ============================================================== ======================================
-   pyflakes_               Find invalid Python code                                       `F <pyflakes codes_>`__
-   pycodestyle_            Enforce style conventions from `PEP 8`_                        `E,W <pycodestyle codes_>`__
-   pep8-naming_            Enforce naming conventions from `PEP 8`_                       `N <pep8-naming codes_>`__
-   flake8-docstrings_      Enforce docstring conventions from `PEP 257`_, via pydocstyle_ `D <pydocstyle codes_>`__
-   flake8-rst-docstrings_  Find invalid reStructuredText_ in docstrings                   `RST <flake8-rst-docstrings codes_>`__
-   flake8-bugbear_         Detect bugs and design problems                                `B <flake8-bugbear codes_>`__
-   mccabe_                 Limit the code complexity                                      `C <mccabe codes_>`__
-   darglint_               Detect inaccurate docstrings                                   `DAR <darglint codes_>`__
-   flake8-bandit_          Detect common security issues, via Bandit_                     `S <Bandit codes_>`__
-   ======================= ============================================================== ======================================
+   ================================ ============================================= ======================================
+   pyflakes_                        Find invalid Python code                      `F <pyflakes codes_>`__
+   pycodestyle_                     Enforce style conventions from `PEP 8`_       `E,W <pycodestyle codes_>`__
+   pep8-naming_                     Enforce naming conventions from `PEP 8`_      `N <pep8-naming codes_>`__
+   pydocstyle_ / flake8-docstrings_ Enforce docstring conventions from `PEP 257`_ `D <pydocstyle codes_>`__
+   flake8-rst-docstrings_           Find invalid reStructuredText_ in docstrings  `RST <flake8-rst-docstrings codes_>`__
+   flake8-bugbear_                  Detect bugs and design problems               `B <flake8-bugbear codes_>`__
+   mccabe_                          Limit the code complexity                     `C <mccabe codes_>`__
+   darglint_                        Detect inaccurate docstrings                  `DAR <darglint codes_>`__
+   Bandit_ / flake8-bandit_         Detect common security issues                 `S <Bandit codes_>`__
+   ================================ ============================================= ======================================
 
 
 The following sections describe the linters in more detail.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -336,7 +336,7 @@ For more details on these files, refer to the section :ref:`The initial package`
    :widths: auto
 
    ===================================== ===============================
-   ``src/<project>/py.typed``            Marker file for `PEP 561`_
+   ``src/<project>/py.typed``            Marker file for `PEP 561`_
    ``src/<project>/__init__.py``         Package initialization
    ``src/<project>/__main__.py``         Command-line interface
    ===================================== ===============================
@@ -490,7 +490,7 @@ under the ``src`` directory::
    This is an empty marker file,
    which declares that your package supports typing
    and is distributed with its own type information
-   (`PEP 561`_).
+   (`PEP 561`_).
    This allows people using your package
    to type-check their Python code against it.
 
@@ -613,7 +613,7 @@ in the root directory of the project,
 and named ``pyproject.toml``.
 It uses the TOML_ configuration file format,
 and contains two sections---*tables* in TOML parlance---,
-specified in `PEP 517`_ and `518 <PEP 518_>`__:
+specified in `PEP 517`_ and `518 <PEP 518_>`__:
 
 - The ``build-system`` table
   declares the requirements and the entry point
@@ -1489,7 +1489,7 @@ The reorder-python-imports hook
 
 reorder-python-imports_ sorts imports in your Python code.
 Imports are separated into three sections,
-as recommended by `PEP 8`_: standard library, third party, first party.
+as recommended by `PEP 8`_: standard library, third party, first party.
 The tool also splits ``from`` imports onto separate lines to avoid merge conflicts,
 and moves them after normal imports.
 Any duplicate imports are removed.
@@ -1520,9 +1520,9 @@ and links to their lists of error codes.
 
    ================================ ============================================= ======================================
    pyflakes_                        Find invalid Python code                      `F <pyflakes codes_>`__
-   pycodestyle_                     Enforce style conventions from `PEP 8`_       `E,W <pycodestyle codes_>`__
-   pep8-naming_                     Enforce naming conventions from `PEP 8`_      `N <pep8-naming codes_>`__
-   pydocstyle_ / flake8-docstrings_ Enforce docstring conventions from `PEP 257`_ `D <pydocstyle codes_>`__
+   pycodestyle_                     Enforce style conventions from `PEP 8`_       `E,W <pycodestyle codes_>`__
+   pep8-naming_                     Enforce naming conventions from `PEP 8`_      `N <pep8-naming codes_>`__
+   pydocstyle_ / flake8-docstrings_ Enforce docstring conventions from `PEP 257`_ `D <pydocstyle codes_>`__
    flake8-rst-docstrings_           Find invalid reStructuredText_ in docstrings  `RST <flake8-rst-docstrings codes_>`__
    flake8-bugbear_                  Detect bugs and design problems               `B <flake8-bugbear codes_>`__
    mccabe_                          Limit the code complexity                     `C <mccabe codes_>`__
@@ -1557,7 +1557,7 @@ pycodestyle
 -----------
 
 The pycodestyle_ tool
-checks your code against many recommendations from `PEP 8`_,
+checks your code against many recommendations from `PEP 8`_,
 the official Python style guide.
 `Error codes`__ are prefixed by ``W`` for warnings and ``E`` for errors.
 The tool detects
@@ -1581,7 +1581,7 @@ for compatibility with Black_ and flake8-bugbear_:
 pep8-naming
 -----------
 
-The pep8-naming_ tool enforces the naming conventions from `PEP 8`_.
+The pep8-naming_ tool enforces the naming conventions from `PEP 8`_.
 `Error codes`__ are prefixed by ``N`` for "naming".
 Examples are the use of camel case for the names of classes,
 the use of lowercase for the names of functions, arguments and variables,
@@ -1595,7 +1595,7 @@ pydocstyle and flake8-docstrings
 --------------------------------
 
 The pydocstyle_ tool is used to check that
-docstrings comply with the recommendations of `PEP 257`_
+docstrings comply with the recommendations of `PEP 257`_
 and a configurable style convention.
 It is integrated via the flake8-docstrings_ extension.
 `Error codes`__ are prefixed by ``D`` for "docstring".
@@ -1946,7 +1946,7 @@ The configuration for Read the Docs is included in the repository,
 in the file `.readthedocs.yml`__.
 The *Hypermodern Python Cookiecutter* configures Read the Docs
 to build and install the package with Poetry,
-using a so-called `PEP 517`_-build.
+using a so-called `PEP 517`_-build.
 
 __ https://docs.readthedocs.io/en/stable/config-file/v2.html
 
@@ -2360,7 +2360,7 @@ Making a release is a two-step process:
 
 .. _poetry version: https://python-poetry.org/docs/cli/#version
 
-When bumping the version, adhere to `Semantic Versioning`_ and `PEP 440`_.
+When bumping the version, adhere to `Semantic Versioning`_ and `PEP 440`_.
 The individual steps for bumping the version are:
 
 .. code:: console
@@ -2435,12 +2435,12 @@ __ https://cjolowicz.github.io/posts/hypermodern-python-01-setup/
 .. _Hypermodern Python Cookiecutter: https://github.com/cjolowicz/cookiecutter-hypermodern-python
 .. _Jinja: https://palletsprojects.com/p/jinja/
 .. _MIT license: https://opensource.org/licenses/MIT
-.. _PEP 257: http://www.python.org/dev/peps/pep-0257/
-.. _PEP 440: https://www.python.org/dev/peps/pep-0440/
-.. _PEP 517: https://www.python.org/dev/peps/pep-0517/
-.. _PEP 518: https://www.python.org/dev/peps/pep-0518/
-.. _PEP 561: https://www.python.org/dev/peps/pep-0561/
-.. _PEP 8: http://www.python.org/dev/peps/pep-0008/
+.. _PEP 257: http://www.python.org/dev/peps/pep-0257/
+.. _PEP 440: https://www.python.org/dev/peps/pep-0440/
+.. _PEP 517: https://www.python.org/dev/peps/pep-0517/
+.. _PEP 518: https://www.python.org/dev/peps/pep-0518/
+.. _PEP 561: https://www.python.org/dev/peps/pep-0561/
+.. _PEP 8: http://www.python.org/dev/peps/pep-0008/
 .. _TOML: https://github.com/toml-lang/toml
 .. _YAML: https://yaml.org/
 .. _bash: https://www.gnu.org/software/bash/


### PR DESCRIPTION
This is an extensive overhaul of the documentation. Many sections have been improved, rewritten, or rearranged.

Originally, this was prompted by the different role of pre-commit. pre-commit is now a first-class citizen of the project template.

- Linting is entirely the responsibility of pre-commit, not Nox.
- pre-commit is run from Nox.
- Black and Flake8 have been moved from Poetry/Nox to pre-commit.