### PR TITLE
Run pre-commit from Nox and Tests workflow

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -939,7 +939,7 @@ The following table gives an overview of the available Nox sessions:
    ========================================== ============================== ================== =========
    :ref:`docs <The docs session>`             Build Sphinx_ documentation    ``3.8``
    :ref:`mypy <The mypy session>`             Type-check with mypy_          ``3.6`` … ``3.8``      ✓
-   :ref:`pre-commit <The pre-commit session>` Lint with pre-commit_          ``3.6`` … ``3.8``
+   :ref:`pre-commit <The pre-commit session>` Lint with pre-commit_          ``3.6`` … ``3.8``      ✓
    :ref:`safety <The safety session>`         Scan dependencies with Safety_ ``3.8``                ✓
    :ref:`tests <The tests session>`           Run tests with pytest_         ``3.6`` … ``3.8``      ✓
    :ref:`typeguard <The typeguard session>`   Type-check with Typeguard_     ``3.6`` … ``3.8``

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -2016,9 +2016,11 @@ The workflow uses the following GitHub Actions:
 
 - `actions/checkout`_ for checking out the Git repository
 - `actions/setup-python`_ for setting up the Python interpreter
+- `actions/cache`_ for caching pre-commit environments
 
 .. _actions/checkout: https://github.com/actions/checkout
 .. _actions/setup-python: https://github.com/actions/setup-python
+.. _actions/cache: https://github.com/actions/cache
 
 The workflow is defined in ``.github/workflows/tests.yml``.
 
@@ -2066,8 +2068,6 @@ The workflow uses the following GitHub Actions:
 - `actions/checkout`_ for checking out the Git repository
 - `actions/setup-python`_ for setting up the Python interpreter
 - `actions/cache`_ for caching pre-commit environments
-
-.. _actions/cache: https://github.com/actions/cache
 
 The workflow runs with the current Python version,
 using the latest Ubuntu, Windows, and macOS runners.

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -13,6 +13,25 @@ jobs:
       - run: |
           pip install --constraint=.github/workflows/constraints.txt pip
           pip install --constraint=.github/workflows/constraints.txt nox poetry
+      - name: Compute cache key prefix
+        id: cache_key_prefix
+        shell: python
+        run: |
+          import hashlib
+          import sys
+
+          python = "py{}.{}".format(*sys.version_info[:2])
+          payload = sys.version.encode() + sys.executable.encode()
+          digest = hashlib.sha256(payload).hexdigest()
+          result = "{% raw %}${{ runner.os }}{% endraw %}-{}-{}-pre-commit".format(python, digest[:8])
+
+          print("::set-output name=result::{}".format(result))
+      - uses: actions/cache@v1.1.2
+        with:
+          path: ~/.cache/pre-commit
+          key: {% raw %}${{ steps.cache_key_prefix.outputs.result }}-${{ hashFiles('.pre-commit-config.yaml') }}{% endraw %}
+          restore-keys: |
+            {% raw %}${{ steps.cache_key_prefix.outputs.result }}{% endraw %}-
       - run: nox --force-color
       - run: poetry build --ansi
       - uses: pypa/gh-action-pypi-publish@v1.1.0

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -13,6 +13,25 @@ jobs:
       - uses: actions/setup-python@v1.2.0
         with:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+      - name: Compute cache key prefix
+        id: cache_key_prefix
+        shell: python
+        run: |
+          import hashlib
+          import sys
+
+          python = "py{}.{}".format(*sys.version_info[:2])
+          payload = sys.version.encode() + sys.executable.encode()
+          digest = hashlib.sha256(payload).hexdigest()
+          result = "{% raw %}${{ runner.os }}{% endraw %}-{}-{}-pre-commit".format(python, digest[:8])
+
+          print("::set-output name=result::{}".format(result))
+      - uses: actions/cache@v1.1.2
+        with:
+          path: ~/.cache/pre-commit
+          key: {% raw %}${{ steps.cache_key_prefix.outputs.result }}-${{ hashFiles('.pre-commit-config.yaml') }}{% endraw %}
+          restore-keys: |
+            {% raw %}${{ steps.cache_key_prefix.outputs.result }}{% endraw %}-
       - run: |
           pip install --constraint=.github/workflows/constraints.txt pip
           pip install --constraint=.github/workflows/constraints.txt nox poetry

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -12,7 +12,7 @@ from nox.sessions import Session
 
 package = "{{cookiecutter.package_name}}"
 python_versions = ["3.8", "3.7", "3.6"]
-nox.options.sessions = "safety", "mypy", "tests"
+nox.options.sessions = "pre-commit", "safety", "mypy", "tests"
 locations = "src", "tests", "noxfile.py", "docs/conf.py"
 
 


### PR DESCRIPTION
Run pre-commit as a part of both local and CI checks, using Nox as a single entry point. This PR adds pre-commit to the default Nox sessions, and enables caching in the Tests and Release workflows.