### PR TITLE
Fix missing type information in mypy session

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -131,6 +131,7 @@ def safety(session: Session) -> None:
 def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or locations
+    install_package(session)
     install(session, "mypy")
     session.run("mypy", *args)
 


### PR DESCRIPTION
Install our package into the Nox session for mypy. mypy needs access to inline type information from our package (and potentially from its core dependencies, if they distribute types).

This fixes invocations like `nox -s mypy -- tests/test_main.py`. If the package is also passed to mypy, the bug is not triggered, because then mypy can access the types from the source tree. So `nox -s mypy` does not manifest the bug, for example, neither does CI.

Closes #242 