### PR TITLE
Bump pre-commit-hooks from v2.5.0 to v3.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: "^{{cookiecutter\\.project_name}}/"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer


### PR DESCRIPTION
- [changelog]

[changelog]: https://github.com/pre-commit/pre-commit-hooks/blob/master/CHANGELOG.md#300---2020-05-14