### PR TITLE
Fix template URL in Reset Instance workflow

### DIFF
--- a/.github/workflows/reset-instance.yml
+++ b/.github/workflows/reset-instance.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Invoke cookiecutter
         run: >-
           cookiecutter
-          cookiecutter-hypermodern-python
+          https://github.com/${GITHUB_REPOSITORY}
           --overwrite-if-exists
           --no-input
           project_name=cookiecutter-hypermodern-python-instance


### PR DESCRIPTION
Generating the project from the local checkout is problematic because it
writes the relative path to the template directory to .cookiecutter.json,
instead of the template URL.

This appears to work when there is already a checkout of the template
because `_template` contains the template name. But it breaks when you
try to use `cookiecutter --checkout` with the template, for example from
my patched version of cupper.

Closes #288