### PR TITLE
Expand generated README.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -16,7 +16,6 @@ Here is a list of important resources for contributors:
 .. _Source Code: https://github.com/cjolowicz/cookiecutter-hypermodern-python
 .. _Documentation: https://cookiecutter-hypermodern-python.readthedocs.io/
 .. _Issue Tracker: https://github.com/cjolowicz/cookiecutter-hypermodern-python/issues
-.. _Code of Conduct: https://cookiecutter-hypermodern-python.readthedocs.io/codeofconduct.html
 
 
 How to report a bug
@@ -170,3 +169,5 @@ After publishing the release, the following automated steps are triggered:
 
 .. _Calendar Versioning: https://calver.org/
 .. _Read the Docs: https://cookiecutter-hypermodern-python.readthedocs.io/
+.. github-only
+.. _Code of Conduct: CODE_OF_CONDUCT.rst

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,1 +1,4 @@
 .. include:: ../CONTRIBUTING.rst
+   :end-before: github-only
+
+.. _Code of Conduct: codeofconduct.html

--- a/{{cookiecutter.project_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_name}}/CONTRIBUTING.rst
@@ -12,10 +12,10 @@ Here is a list of important resources for contributors:
 - `Issue Tracker`_
 - `Code of Conduct`_
 
-.. _`MIT license`: https://opensource.org/licenses/MIT
-.. _`Source Code`: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}
-.. _`Documentation`: https://{{cookiecutter.project_name}}.readthedocs.io/
-.. _`Issue Tracker`: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/issues
+.. _MIT license: https://opensource.org/licenses/MIT
+.. _Source Code: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}
+.. _Documentation: https://{{cookiecutter.project_name}}.readthedocs.io/
+.. _Issue Tracker: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/issues
 
 How to report a bug
 -------------------
@@ -62,8 +62,8 @@ or the command-line interface:
    $ poetry run python
    $ poetry run {{cookiecutter.project_name}}
 
-.. _`Poetry`: https://python-poetry.org/
-.. _`Nox`: https://nox.thea.codes/
+.. _Poetry: https://python-poetry.org/
+.. _Nox: https://nox.thea.codes/
 
 
 How to test the project
@@ -91,7 +91,7 @@ For example, invoke the unit test suite like this:
 Unit tests are located in the ``tests`` directory,
 and are written using the pytest_ testing framework.
 
-.. _`pytest`: https://pytest.readthedocs.io/
+.. _pytest: https://pytest.readthedocs.io/
 
 
 How to submit changes
@@ -116,7 +116,7 @@ You can ensure that your changes adhere to the code style by reformatting with B
 It is recommended to open an issue before starting work on anything.
 This will allow a chance to talk it over with the owners and validate your approach.
 
-.. _`pull request`: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/pulls
-.. _`Black`: https://black.readthedocs.io/
+.. _pull request: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/pulls
+.. _Black: https://black.readthedocs.io/
 .. github-only
-.. _`Code of Conduct`: CODE_OF_CONDUCT.rst
+.. _Code of Conduct: CODE_OF_CONDUCT.rst

--- a/{{cookiecutter.project_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_name}}/CONTRIBUTING.rst
@@ -16,7 +16,6 @@ Here is a list of important resources for contributors:
 .. _`Source Code`: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}
 .. _`Documentation`: https://{{cookiecutter.project_name}}.readthedocs.io/
 .. _`Issue Tracker`: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/issues
-.. _`Code of Conduct`: https://{{cookiecutter.project_name}}.readthedocs.io/codeofconduct.html
 
 How to report a bug
 -------------------
@@ -119,3 +118,5 @@ This will allow a chance to talk it over with the owners and validate your appro
 
 .. _`pull request`: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/pulls
 .. _`Black`: https://black.readthedocs.io/
+.. github-only
+.. _`Code of Conduct`: CODE_OF_CONDUCT.rst

--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -1,8 +1,6 @@
 {{cookiecutter.friendly_name}}
 ========================================
 
-.. badges-begin
-
 |Tests| |Codecov| |PyPI| |Python Version| |Read the Docs| |License| |Black| |pre-commit| |Dependabot|
 
 .. |Tests| image:: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/workflows/Tests/badge.svg
@@ -33,7 +31,6 @@
    :target: https://dependabot.com
    :alt: Dependabot
 
-.. badges-end
 
 Features
 --------
@@ -97,4 +94,5 @@ This project was generated from `@cjolowicz`_'s `Hypermodern Python Cookiecutter
 .. _Hypermodern Python Cookiecutter: https://github.com/cjolowicz/cookiecutter-hypermodern-python
 .. _file an issue: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/issues
 .. _pip: https://pip.pypa.io/
+.. github-only
 .. _Contributor Guide: CONTRIBUTING.rst

--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -1,4 +1,4 @@
-{{cookiecutter.project_name}}
+{{cookiecutter.friendly_name}}
 ========================================
 
 .. badges-begin
@@ -34,3 +34,67 @@
    :alt: Dependabot
 
 .. badges-end
+
+Features
+--------
+
+* TODO
+
+
+Requirements
+------------
+
+* TODO
+
+
+Installation
+------------
+
+You can install *{{cookiecutter.friendly_name}}* via pip_ from PyPI_:
+
+.. code:: console
+
+   $ pip install {{cookiecutter.project_name}}
+
+
+Usage
+-----
+
+* TODO
+
+
+Contributing
+------------
+
+Contributions are very welcome.
+To learn more, see the `Contributor Guide`_.
+
+
+License
+-------
+
+Distributed under the terms of the MIT_ license,
+*{{cookiecutter.friendly_name}}* is free and open source software.
+
+
+Issues
+------
+
+If you encounter any problems,
+please `file an issue`_ along with a detailed description.
+
+
+Credits
+-------
+
+This project was generated from `@cjolowicz`_'s `Hypermodern Python Cookiecutter`_ template.
+
+
+.. _@cjolowicz: https://github.com/cjolowicz
+.. _Cookiecutter: https://github.com/audreyr/cookiecutter
+.. _MIT: http://opensource.org/licenses/MIT
+.. _PyPI: https://pypi.org/
+.. _Hypermodern Python Cookiecutter: https://github.com/cjolowicz/cookiecutter-hypermodern-python
+.. _file an issue: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/issues
+.. _pip: https://pip.pypa.io/
+.. _Contributor Guide: CONTRIBUTING.rst

--- a/{{cookiecutter.project_name}}/docs/contributing.rst
+++ b/{{cookiecutter.project_name}}/docs/contributing.rst
@@ -1,1 +1,4 @@
 .. include:: ../CONTRIBUTING.rst
+   :end-before: github-only
+
+.. _Code of Conduct: codeofconduct.html

--- a/{{cookiecutter.project_name}}/docs/index.rst
+++ b/{{cookiecutter.project_name}}/docs/index.rst
@@ -1,5 +1,7 @@
-{{cookiecutter.friendly_name}}
-==============================
+.. include:: ../README.rst
+   :end-before: github-only
+
+.. _Contributor Guide: contributing.html
 
 .. toctree::
    :hidden:
@@ -10,38 +12,3 @@
    Code of Conduct <codeofconduct>
    License <license>
    Changelog <https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/releases>
-
-.. include:: ../README.rst
-   :start-after: badges-begin
-   :end-before: badges-end
-
-This package has a command-line interface.
-
-
-Installation
-------------
-
-To install {{cookiecutter.friendly_name}},
-run this command in your terminal:
-
-.. code-block:: console
-
-   $ pip install {{cookiecutter.project_name}}
-
-
-Usage
------
-
-{{cookiecutter.friendly_name}}'s usage looks like:
-
-.. code-block:: console
-
-   $ {{cookiecutter.project_name}} [OPTIONS]
-
-.. option:: --version
-
-   Display the version and exit.
-
-.. option:: --help
-
-   Display a short usage message and exit.


### PR DESCRIPTION
Add the following sections to the generated README.rst:

- Features (empty)
- Requirements (empty)
- Installation
- Usage (empty)
- Contributing
- License
- Issues
- Credits

The structure is based on @hackebrot's cookiecutter-pytest-plugin.

Closes #205 
Closes #284 