### PR TITLE
Fix missing underlines on some links

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -70,6 +70,6 @@ ol {
 }
 
 /* Do not underline badges */
-.body p:first-of-type a.reference {
+.badges a.reference {
   border-bottom: 0px;
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,8 @@ Hypermodern Python Cookiecutter
    License <license>
    Changelog <https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases>
 
+.. rst-class:: badges
+
 .. include:: ../README.rst
    :start-after: badges-begin
    :end-before: badges-end


### PR DESCRIPTION
Links in the first paragraph of every section are not underlined. This is because the CSS selector intended for badges (#297) matches these links erroneously.

Precede the badges by an `.. rst-class:: badges` directive. This wraps them in an HTML element with the badges class, which can easily be targeted in CSS.

```html
  <p class="badges>
    ...
  </p>
```

Closes #302 