### PR TITLE
Remove */site-packages path prefix from coverage report

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -141,7 +141,8 @@ def tests(session: Session) -> None:
     """Run the test suite."""
     install_package(session)
     install(session, "coverage[toml]", "pytest")
-    session.run("coverage", "run", "-m", "pytest", *session.posargs)
+    session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
+    session.run("coverage", "combine")
     session.run("coverage", "report")
 
 


### PR DESCRIPTION
In `tool.coverage.paths.source`, the following paths are specified as equivalent:

- `src`
- `*/site-packages`

Since tests run against the installed package, the report displays the second, longer path prefix. But we can get coverage reports to use the shorter first form by processing coverage data with `coverage combine`. And for that, we need to run coverage with `--parallel`.

See https://hynek.me/articles/testing-packaging/