### PR TITLE
Allow coverage session to be run stand-alone

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1244,6 +1244,14 @@ You can also run the session manually:
 
    $ nox --session=coverage
 
+Use the ``--`` separator to pass arguments to the ``coverage`` command.
+For example, here's how you would generate an HTML report
+in the ``htmlcov`` directory:
+
+.. code:: console
+
+   $ nox -rs coverage -- html
+
 Coverage.py_ is configured in the ``pyproject.toml`` file,
 using the ``tool.coverage`` table.
 The configuration informs the tool about your package name and source tree layout.

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -150,7 +150,8 @@ def coverage(session: Session) -> None:
     """Produce the coverage report."""
     args = session.posargs or ["report"]
     install(session, "coverage[toml]")
-    session.run("coverage", "combine")
+    if not session.posargs and any(Path().glob(".coverage.*")):
+        session.run("coverage", "combine")
     session.run("coverage", *args)
 
 

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -148,9 +148,10 @@ def tests(session: Session) -> None:
 @nox.session
 def coverage(session: Session) -> None:
     """Produce the coverage report."""
+    args = session.posargs or ["report"]
     install(session, "coverage[toml]")
     session.run("coverage", "combine")
-    session.run("coverage", "report")
+    session.run("coverage", *args)
 
 
 @nox.session(python=python_versions)


### PR DESCRIPTION
Do not combine coverage data when the coverage session is invoked with
arguments, or when there are no data files to be combined.

Combining coverage data is only possible when there are unprocessed
coverage files, such as when triggered by the tests session. This makes
it impossible to use the coverage session on its own. Use cases for that
include the following:

  - Creating an XML coverage report for Codecov during CI
  - Interacting with `coverage` directly during development

Note that this change means that the coverage session is not strictly
idempotent:

  - If there are unprocessed data files, the session combines the files,
    erasing the existing data (and removing the files).

  - If there are no unprocessed data files, the session simply displays
    the existing data.

This behavior appears acceptable because unprocessed data files are
normally only visible during a Nox run, so any coverage session run on
explicit user request _will_ be idempotent.

One case where this becomes relevant is after an aborted Nox run: If
invoked with arguments, the coverage session will show coverage data
from a previous run, or fail if there wasn't a previous run. If invoked
without arguments, the session will show the partial data from the
aborted run.

Rejected ideas:

  Append the coverage data to the combined report in the tests session,
  using `coverage combine --append`. This means coverage data needs to
  be erased explicitly. If you don't remember to erase it, you won't
  notice coverage drops during local testing.