### PR TITLE
Only run the targeted Python version in each CI job

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -14,14 +14,14 @@ jobs:
         include:
           - { python-version: 3.8, os: ubuntu-latest, session: "pre-commit" }
           - { python-version: 3.8, os: ubuntu-latest, session: "safety" }
-          - { python-version: 3.8, os: ubuntu-latest, session: "mypy" }
-          - { python-version: 3.7, os: ubuntu-latest, session: "mypy" }
-          - { python-version: 3.6, os: ubuntu-latest, session: "mypy" }
-          - { python-version: 3.8, os: ubuntu-latest, session: "tests" }
-          - { python-version: 3.7, os: ubuntu-latest, session: "tests" }
-          - { python-version: 3.6, os: ubuntu-latest, session: "tests" }
-          - { python-version: 3.8, os: windows-latest, session: "tests" }
-          - { python-version: 3.8, os: macos-latest, session: "tests" }
+          - { python-version: 3.8, os: ubuntu-latest, session: "mypy-3.8" }
+          - { python-version: 3.7, os: ubuntu-latest, session: "mypy-3.7" }
+          - { python-version: 3.6, os: ubuntu-latest, session: "mypy-3.6" }
+          - { python-version: 3.8, os: ubuntu-latest, session: "tests-3.8" }
+          - { python-version: 3.7, os: ubuntu-latest, session: "tests-3.7" }
+          - { python-version: 3.6, os: ubuntu-latest, session: "tests-3.6" }
+          - { python-version: 3.8, os: windows-latest, session: "tests-3.8" }
+          - { python-version: 3.8, os: macos-latest, session: "tests-3.8" }
           - { python-version: 3.8, os: ubuntu-latest, session: "docs" }
 
     env:


### PR DESCRIPTION
The mypy and tests jobs were running with any Python version installed on the runner. If a registered Python version for the session was not installed on the runner, they would print a message that the session was skipped.

Avoid all of this, and specifically run the session for the targeted Python version (as specified in `matrix.python-version`).