### PR TITLE
Adapt Coverage workflow to use coverage session

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -2139,7 +2139,7 @@ The Coverage workflow uploads coverage data to Codecov_.
 
 The workflow is triggered on every push to the GitHub repository,
 and when a pull request is opened or receives new commits.
-It executes the :ref:`tests session <the tests session>`
+It executes the :ref:`coverage session <The coverage session>`
 to generate a coverage report in cobertura__ XML format.
 This coverage report is then uploaded to Codecov_.
 

--- a/{{cookiecutter.project_name}}/.github/workflows/coverage.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/coverage.yml
@@ -11,5 +11,6 @@ jobs:
       - run: |
           pip install --constraint=.github/workflows/constraints.txt pip
           pip install --constraint=.github/workflows/constraints.txt nox poetry
-      - run: nox --force-color --session=tests-3.8 -- --cov --cov-report=xml || true
+      - run: nox --force-color --session=tests-3.8 || true
+      - run: nox --force-color --session=coverage -- xml
       - uses: codecov/codecov-action@v1.0.7

--- a/{{cookiecutter.project_name}}/.github/workflows/coverage.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/coverage.yml
@@ -11,6 +11,5 @@ jobs:
       - run: |
           pip install --constraint=.github/workflows/constraints.txt pip
           pip install --constraint=.github/workflows/constraints.txt nox poetry
-      - run: nox --force-color --session=tests-3.8 -- --cov --cov-report=xml
-      - if: always()
-        uses: codecov/codecov-action@v1.0.7
+      - run: nox --force-color --session=tests-3.8 -- --cov --cov-report=xml || true
+      - uses: codecov/codecov-action@v1.0.7


### PR DESCRIPTION
The Coverage workflow was broken by the removal of pytest-cov in #305. This PR adapts the Coverage workflow to use the new coverage session introduced in #312 and #315. This is an interim change before merging the Coverage workflow into the Tests workflow.