### PR TITLE
Pin virtualenv to 20.0.21

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -2062,8 +2062,11 @@ Constraints file
 GitHub Actions workflows install the following tools:
 
 - pip_
+- virtualenv_
 - Poetry_
 - Nox_
+
+.. _virtualenv: https://virtualenv.pypa.io/
 
 These dependencies are pinned using a `constraints file`_
 located in ``.github/workflow/constraints.txt``.

--- a/{{cookiecutter.project_name}}/.github/workflows/constraints.txt
+++ b/{{cookiecutter.project_name}}/.github/workflows/constraints.txt
@@ -1,3 +1,4 @@
 pip==20.1.1
 nox==2019.11.9
 poetry==1.0.5
+virtualenv==20.0.21


### PR DESCRIPTION
virtualenv uses the bundled pip by default. As a result, Nox sessions do not use the pip specified in our constraints file. This change pins virtualenv to the latest version, which bundles the latest pip at the time of the virtualenv release. virtualenv releases are timed to occur in a small time window after pip releases.

Note that Nox sessions continue to use the bundled pip instead of the one specified in the constraints file, so the real problem is not addressed. I first thought that this would require Nox to expose virtualenv's `--pip` option. But it appears that you can also pass the pip version to virtualenv using the `VIRTUALENV_PIP` environment variable. Alas, this will mean boilerplate in the workflow definition, and/or a duplication of the pip version from constraints.txt.

See #324 

