### PR TITLE
Type-check noxfile.py

### DIFF
--- a/{{cookiecutter.project_name}}/mypy.ini
+++ b/{{cookiecutter.project_name}}/mypy.ini
@@ -19,14 +19,8 @@ warn_unreachable = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
-[mypy-noxfile]
-disallow_untyped_decorators = False
-
 [mypy-tests.*]
 disallow_untyped_decorators = False
-
-[mypy-nox.*]
-ignore_missing_imports = True
 
 [mypy-pytest]
 ignore_missing_imports = True

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -14,7 +14,6 @@ from nox.sessions import Session
 package = "{{cookiecutter.package_name}}"
 python_versions = ["3.8", "3.7", "3.6"]
 nox.options.sessions = "pre-commit", "safety", "mypy", "tests"
-locations = "src", "tests", "noxfile.py", "docs/conf.py"
 
 
 class Poetry:

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -1,6 +1,7 @@
 """Nox sessions."""
 import contextlib
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 from typing import cast
@@ -130,10 +131,12 @@ def safety(session: Session) -> None:
 @nox.session(python=python_versions)
 def mypy(session: Session) -> None:
     """Type-check using mypy."""
-    args = session.posargs or locations
+    args = session.posargs or ["src", "tests", "docs/conf.py"]
     install_package(session)
     install(session, "mypy")
     session.run("mypy", *args)
+    if not session.posargs:
+        session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
 
 
 @nox.session(python=python_versions)


### PR DESCRIPTION
Use the [--python-executable] option to mypy to point the type checker to the Python installation running Nox, rather than the virtual environment of the Nox session, when type-checking `noxfile.py` itself. This allows mypy to find the type information for Nox, without having to install Nox into the session. Nox distributes type information inline and declares this fact using the py.typed file specified in [PEP 561].

[--python-executable]: https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-python-executable
[PEP 561]: https://www.python.org/dev/peps/pep-0561/

Note that this check is somewhat indeterministic in local testing. The Nox version is only pinned in CI. For users with a pre-2020.5.24 version of Nox, the session will fail due to missing type hints. The session may also conceivably fail in the future if users install a newer version of Nox with breaking changes. (In the latter case, the failure serves as a useful reminder that noxfile.py needs to be adapted to the API changes.)

Closes #337 