### PR TITLE
Fix leading blank line in README and API reference

### DIFF
--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -1,7 +1,7 @@
 {%- macro heading(text) -%}
 {{text}}
 {% for _ in text %}={% endfor %}
-{%- endmacro %}
+{%- endmacro -%}
 {{ heading(cookiecutter.friendly_name) }}
 
 |Tests| |Codecov| |PyPI| |Python Version| |Read the Docs| |License| |Black| |pre-commit| |Dependabot|

--- a/{{cookiecutter.project_name}}/docs/reference.rst
+++ b/{{cookiecutter.project_name}}/docs/reference.rst
@@ -1,7 +1,7 @@
 {%- macro heading(text) -%}
 {{text}}
 {% for _ in text %}-{% endfor %}
-{%- endmacro %}
+{%- endmacro -%}
 Reference
 =========
 


### PR DESCRIPTION
The files `README.rst` and `reference.rst` start with a blank line, due to a Jinja macro definition at the top of these files. Eliminate the blank line by ending the macro definition with `-%}`.

Closes #350 