### PR TITLE
Enable runtime type-checking with Typeguard by default

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1060,7 +1060,7 @@ The following table gives an overview of the available Nox sessions:
    :ref:`pre-commit <The pre-commit session>` Lint with pre-commit_             ``3.8``                ✓
    :ref:`safety <The safety session>`         Scan dependencies with Safety_    ``3.8``                ✓
    :ref:`tests <The tests session>`           Run tests with pytest_            ``3.6`` … ``3.8``      ✓
-   :ref:`typeguard <The typeguard session>`   Type-check with Typeguard_        ``3.6`` … ``3.8``
+   :ref:`typeguard <The typeguard session>`   Type-check with Typeguard_        ``3.6`` … ``3.8``      ✓
    :ref:`xdoctest <The xdoctest session>`     Run examples with xdoctest_       ``3.6`` … ``3.8``
    ========================================== ================================= ================== =========
 

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
           - { python-version: 3.6, os: ubuntu-latest, session: "tests" }
           - { python-version: 3.8, os: windows-latest, session: "tests" }
           - { python-version: 3.8, os: macos-latest, session: "tests" }
+          - { python-version: 3.8, os: ubuntu-latest, session: "typeguard" }
           - { python-version: 3.8, os: ubuntu-latest, session: "docs" }
 
     env:

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -13,7 +13,7 @@ from nox.sessions import Session
 
 package = "{{cookiecutter.package_name}}"
 python_versions = ["3.8", "3.7", "3.6"]
-nox.options.sessions = "pre-commit", "safety", "mypy", "tests"
+nox.options.sessions = "pre-commit", "safety", "mypy", "tests", "typeguard"
 
 
 class Poetry:


### PR DESCRIPTION
- Add typeguard session to the default Nox sessions
- Add typeguard session to the Tests workflow