### PR TITLE
Organize badges in multiple rows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,14 +9,13 @@ cookiecutter-hypermodern-python
 
 .. badges-begin
 
-|Python Version| |CalVer| |License|
+| |Status| |Python Version| |CalVer| |License|
+| |Read the Docs| |Tests| |Codecov|
+| |pre-commit| |Dependabot| |Black|
 
-|Read the Docs|
-
-|Status| |Tests| |Codecov|
-
-|pre-commit| |Dependabot| |Black|
-
+.. |Status| image:: https://badgen.net/badge/status/alpha/d8624d
+   :target: https://badgen.net/badge/status/alpha/d8624d
+   :alt: Project Status
 .. |Python Version| image:: https://img.shields.io/pypi/pyversions/cookiecutter-hypermodern-python-instance
    :target: https://github.com/cjolowicz/cookiecutter-hypermodern-python
    :alt: Python Version
@@ -26,12 +25,9 @@ cookiecutter-hypermodern-python
 .. |License| image:: https://img.shields.io/github/license/cjolowicz/cookiecutter-hypermodern-python
    :target: https://opensource.org/licenses/MIT
    :alt: License
-.. |Read the Docs| image:: https://img.shields.io/readthedocs/cookiecutter-hypermodern-python/latest.svg?style=flat-square&label=Read%20the%20Docs
+.. |Read the Docs| image:: https://readthedocs.org/projects/cookiecutter-hypermodern-python/badge/
    :target: https://cookiecutter-hypermodern-python.readthedocs.io/
-   :alt: Read the documentation at https://cookiecutter-hypermodern-python.readthedocs.io/
-.. |Status| image:: https://badgen.net/badge/status/alpha/d8624d
-   :target: https://badgen.net/badge/status/alpha/d8624d
-   :alt: Project Status
+   :alt: Read the Docs
 .. |Tests| image:: https://github.com/cjolowicz/cookiecutter-hypermodern-python/workflows/Tests/badge.svg
    :target: https://github.com/cjolowicz/cookiecutter-hypermodern-python/actions?workflow=Tests
    :alt: Tests

--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,9 @@ cookiecutter-hypermodern-python
 .. |License| image:: https://img.shields.io/github/license/cjolowicz/cookiecutter-hypermodern-python
    :target: https://opensource.org/licenses/MIT
    :alt: License
-.. |Read the Docs| image:: https://readthedocs.org/projects/cookiecutter-hypermodern-python/badge/
+.. |Read the Docs| image:: https://img.shields.io/readthedocs/cookiecutter-hypermodern-python/latest.svg?label=Read%20the%20Docs
    :target: https://cookiecutter-hypermodern-python.readthedocs.io/
-   :alt: Read the Docs
+   :alt: Read the documentation at https://cookiecutter-hypermodern-python.readthedocs.io/
 .. |Tests| image:: https://github.com/cjolowicz/cookiecutter-hypermodern-python/workflows/Tests/badge.svg
    :target: https://github.com/cjolowicz/cookiecutter-hypermodern-python/actions?workflow=Tests
    :alt: Tests

--- a/README.rst
+++ b/README.rst
@@ -9,38 +9,44 @@ cookiecutter-hypermodern-python
 
 .. badges-begin
 
-|Status| |Python Version| |License| |Black| |pre-commit| |Dependabot| |CalVer| |Tests| |Read the Docs| |Codecov|
+|Python Version| |CalVer| |License|
 
-.. |Status| image:: https://badgen.net/badge/status/alpha/d8624d
-   :target: https://badgen.net/badge/status/alpha/d8624d
-   :alt: Project Status
+|Read the Docs|
+
+|Status| |Tests| |Codecov|
+
+|pre-commit| |Dependabot| |Black|
+
 .. |Python Version| image:: https://img.shields.io/pypi/pyversions/cookiecutter-hypermodern-python-instance
    :target: https://github.com/cjolowicz/cookiecutter-hypermodern-python
    :alt: Python Version
+.. |CalVer| image:: https://img.shields.io/badge/calver-YYYY.MM.DD-22bfda.svg
+   :target: http://calver.org/
+   :alt: CalVer
 .. |License| image:: https://img.shields.io/github/license/cjolowicz/cookiecutter-hypermodern-python
    :target: https://opensource.org/licenses/MIT
    :alt: License
-.. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/psf/black
-   :alt: Black
+.. |Read the Docs| image:: https://img.shields.io/readthedocs/cookiecutter-hypermodern-python/latest.svg?style=flat-square&label=Read%20the%20Docs
+   :target: https://cookiecutter-hypermodern-python.readthedocs.io/
+   :alt: Read the documentation at https://cookiecutter-hypermodern-python.readthedocs.io/
+.. |Status| image:: https://badgen.net/badge/status/alpha/d8624d
+   :target: https://badgen.net/badge/status/alpha/d8624d
+   :alt: Project Status
+.. |Tests| image:: https://github.com/cjolowicz/cookiecutter-hypermodern-python/workflows/Tests/badge.svg
+   :target: https://github.com/cjolowicz/cookiecutter-hypermodern-python/actions?workflow=Tests
+   :alt: Tests
+.. |Codecov| image:: https://codecov.io/gh/cjolowicz/cookiecutter-hypermodern-python-instance/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/cjolowicz/cookiecutter-hypermodern-python-instance
+   :alt: Codecov
 .. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
    :target: https://github.com/pre-commit/pre-commit
    :alt: pre-commit
 .. |Dependabot| image:: https://api.dependabot.com/badges/status?host=github&repo=cjolowicz/cookiecutter-hypermodern-python-instance
    :target: https://dependabot.com
    :alt: Dependabot
-.. |CalVer| image:: https://img.shields.io/badge/calver-YYYY.MM.DD-22bfda.svg
-   :target: http://calver.org/
-   :alt: CalVer
-.. |Tests| image:: https://github.com/cjolowicz/cookiecutter-hypermodern-python/workflows/Tests/badge.svg
-   :target: https://github.com/cjolowicz/cookiecutter-hypermodern-python/actions?workflow=Tests
-   :alt: Tests
-.. |Read the Docs| image:: https://readthedocs.org/projects/cookiecutter-hypermodern-python/badge/
-   :target: https://cookiecutter-hypermodern-python.readthedocs.io/
-   :alt: Read the Docs
-.. |Codecov| image:: https://codecov.io/gh/cjolowicz/cookiecutter-hypermodern-python-instance/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/cjolowicz/cookiecutter-hypermodern-python-instance
-   :alt: Codecov
+.. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
+   :target: https://github.com/psf/black
+   :alt: Black
 
 .. badges-end
 

--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -6,9 +6,7 @@
 
 |PyPI| |Python Version| |License|
 
-|Read the Docs|
-
-|Tests| |Codecov|
+|Read the Docs| |Tests| |Codecov|
 
 |pre-commit| |Dependabot| |Black|
 
@@ -21,9 +19,9 @@
 .. |License| image:: https://img.shields.io/pypi/l/{{cookiecutter.project_name}}
    :target: https://opensource.org/licenses/MIT
    :alt: License
-.. |Read the Docs| image:: https://img.shields.io/readthedocs/{{cookiecutter.project_name}}/latest.svg?style=flat-square&label=Read%20the%20Docs
+.. |Read the Docs| image:: https://readthedocs.org/projects/{{cookiecutter.project_name}}/badge/
    :target: https://{{cookiecutter.project_name}}.readthedocs.io/
-   :alt: Read the documentation at https://{{cookiecutter.project_name}}.readthedocs.io/
+   :alt: Read the Docs
 .. |Tests| image:: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/workflows/Tests/badge.svg
    :target: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/actions?workflow=Tests
    :alt: Tests

--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -4,35 +4,41 @@
 {%- endmacro -%}
 {{ heading(cookiecutter.friendly_name) }}
 
-|Tests| |Codecov| |PyPI| |Python Version| |Read the Docs| |License| |Black| |pre-commit| |Dependabot|
+|PyPI| |Python Version| |License|
 
-.. |Tests| image:: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/workflows/Tests/badge.svg
-   :target: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/actions?workflow=Tests
-   :alt: Tests
-.. |Codecov| image:: https://codecov.io/gh/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}
-   :alt: Codecov
+|Read the Docs|
+
+|Tests| |Codecov| 
+
+|pre-commit| |Dependabot| |Black|
+
 .. |PyPI| image:: https://img.shields.io/pypi/v/{{cookiecutter.project_name}}.svg
    :target: https://pypi.org/project/{{cookiecutter.project_name}}/
    :alt: PyPI
 .. |Python Version| image:: https://img.shields.io/pypi/pyversions/{{cookiecutter.project_name}}
    :target: https://pypi.org/project/{{cookiecutter.project_name}}
    :alt: Python Version
-.. |Read the Docs| image:: https://readthedocs.org/projects/{{cookiecutter.project_name}}/badge/
-   :target: https://{{cookiecutter.project_name}}.readthedocs.io/
-   :alt: Read the Docs
 .. |License| image:: https://img.shields.io/pypi/l/{{cookiecutter.project_name}}
    :target: https://opensource.org/licenses/MIT
    :alt: License
-.. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/psf/black
-   :alt: Black
+.. |Read the Docs| image:: https://img.shields.io/readthedocs/{{cookiecutter.project_name}}/latest.svg?style=flat-square&label=Read%20the%20Docs
+   :target: https://{{cookiecutter.project_name}}.readthedocs.io/
+   :alt: Read the documentation at https://{{cookiecutter.project_name}}.readthedocs.io/
+.. |Tests| image:: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/workflows/Tests/badge.svg
+   :target: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/actions?workflow=Tests
+   :alt: Tests
+.. |Codecov| image:: https://codecov.io/gh/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}
+   :alt: Codecov
 .. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
    :target: https://github.com/pre-commit/pre-commit
    :alt: pre-commit
 .. |Dependabot| image:: https://api.dependabot.com/badges/status?host=github&repo={{cookiecutter.github_user}}/{{cookiecutter.project_name}}
    :target: https://dependabot.com
    :alt: Dependabot
+.. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
+   :target: https://github.com/psf/black
+   :alt: Black
 
 
 Features

--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -8,7 +8,7 @@
 
 |Read the Docs|
 
-|Tests| |Codecov| 
+|Tests| |Codecov|
 
 |pre-commit| |Dependabot| |Black|
 

--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -19,9 +19,9 @@
 .. |License| image:: https://img.shields.io/pypi/l/{{cookiecutter.project_name}}
    :target: https://opensource.org/licenses/MIT
    :alt: License
-.. |Read the Docs| image:: https://readthedocs.org/projects/{{cookiecutter.project_name}}/badge/
+.. |Read the Docs| image:: https://img.shields.io/readthedocs/{{cookiecutter.project_name}}/latest.svg?label=Read%20the%20Docs
    :target: https://{{cookiecutter.project_name}}.readthedocs.io/
-   :alt: Read the Docs
+   :alt: Read the documentation at https://{{cookiecutter.project_name}}.readthedocs.io/
 .. |Tests| image:: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/workflows/Tests/badge.svg
    :target: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/actions?workflow=Tests
    :alt: Tests


### PR DESCRIPTION
* Added the second option you suggested (with Read the docs on a separate row).
* Reordered links to follow same order than are shown.
* Changed Read the docs badge to the one used in https://github.com/dateutil/dateutil/blob/fc9b1625ebc729f01e449879b6b140abd12ae621/README.rst
* Also changed the README.md from the cookiecutter using very similar logic.

Closes #403