### PR TITLE
Update documentation for Python 3.7.8 and 3.6.11

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -152,8 +152,8 @@ This project template supports Python 3.6, 3.7, and 3.8.
 
 .. code:: console
 
-   $ pyenv install 3.6.10
-   $ pyenv install 3.7.7
+   $ pyenv install 3.6.11
+   $ pyenv install 3.7.8
    $ pyenv install 3.8.3
 
 After creating your project (see :ref:`below <Creating a project>`),
@@ -162,7 +162,7 @@ using the following command:
 
 .. code:: console
 
-   $ pyenv local 3.8.3 3.7.7 3.6.10
+   $ pyenv local 3.8.3 3.7.8 3.6.11
 
 The first version listed is the one used when you type plain ``python``.
 Every version can be used by invoking ``python<major.minor>``.


### PR DESCRIPTION
Update the pyenv section in the User Guide to the latest Python versions in the 3.6 and 3.7 release series.