### PR TITLE
Move darglint configuration to .flake8

### DIFF
--- a/{{cookiecutter.project_name}}/.darglint
+++ b/{{cookiecutter.project_name}}/.darglint
@@ -1,2 +1,0 @@
-[darglint]
-strictness = short

--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -5,3 +5,4 @@ max-line-length = 80
 max-complexity = 10
 docstring-convention = google
 per-file-ignores = tests/*:S101
+strictness = short


### PR DESCRIPTION
[Darglint] can be configured using flake8's configuration file, since version [1.5.0].

[darglint]: https://github.com/terrencepreilly/darglint
[1.5.0]: https://github.com/terrencepreilly/darglint/blob/master/CHANGELOG.md#150
