### PR TITLE
Reorder sections in mypy.ini

### DIFF
--- a/{{cookiecutter.project_name}}/mypy.ini
+++ b/{{cookiecutter.project_name}}/mypy.ini
@@ -19,8 +19,8 @@ warn_unreachable = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
-[mypy-tests.*]
-disallow_untyped_decorators = False
-
 [mypy-pytest]
 ignore_missing_imports = True
+
+[mypy-tests.*]
+disallow_untyped_decorators = False


### PR DESCRIPTION
Sort the `[mypy-<package>]` sections in `mypy.ini` alphabetically. It is common to have many of these, for example to ignore missing imports in third-party dependencies, so sorting makes the file more maintainable.
