### PR TITLE
Remove black nox session from documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -90,17 +90,11 @@ Your pull request needs to meet the following guidelines for acceptance:
 
 Feel free to submit early, though—we can always iterate on this.
 
-You can ensure that your changes adhere to the code style by reformatting with Black_:
-
-.. code:: console
-
-   $ nox --session=black
 
 It is recommended to open an issue before starting work on anything.
 This will allow a chance to talk it over with the owners and validate your approach.
 
 .. _pull request: https://github.com/cjolowicz/cookiecutter-hypermodern-python/pulls
-.. _Black: https://black.readthedocs.io/
 
 
 How to accept changes

--- a/{{cookiecutter.project_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_name}}/CONTRIBUTING.rst
@@ -107,16 +107,15 @@ Your pull request needs to meet the following guidelines for acceptance:
 
 Feel free to submit early, though—we can always iterate on this.
 
-You can ensure that your changes adhere to the code style by reformatting with Black_:
+To run linting and code formatting checks before commiting your change, you can install pre-commit as a Git hook by running the following command:
 
 .. code:: console
 
-   $ nox --session=black
+   $ nox --session=pre-commit -- install
 
 It is recommended to open an issue before starting work on anything.
 This will allow a chance to talk it over with the owners and validate your approach.
 
 .. _pull request: https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}/pulls
-.. _Black: https://black.readthedocs.io/
 .. github-only
 .. _Code of Conduct: CODE_OF_CONDUCT.rst


### PR DESCRIPTION
As discussed in #471 current documentation is referencing a nox black session.

This is no more used. Reference is removed in cookiecutter-hypermoern-python project and replace by explanation how to install the pre-commit hook for the project template.

fix #471 