### PR TITLE
Move darglint config to .flake8

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -401,7 +401,6 @@ and links each file to a section with more details.
 
    ===================================== ========================================
    ``.cookiecutter.json``                :ref:`Project variables <Creating a project>`
-   ``.darglint``                         Configuration for :ref:`darglint <darglint integration>`
    ``.github/dependabot.yml``            Configuration for :ref:`Dependabot <Dependabot integration>`
    ``.flake8``                           Configuration for :ref:`Flake8 <The Flake8 hook>`
    ``.gitattributes``                    `Git attributes <.gitattributes_>`__
@@ -1891,7 +1890,6 @@ darglint
 --------
 
 darglint_ checks that docstring descriptions match function definitions.
-The tool has its own configuration file, named ``.darglint``.
 
 `Error codes`__ are prefixed by ``DAR`` for "darglint".
 

--- a/{{cookiecutter.project_name}}/.darglint
+++ b/{{cookiecutter.project_name}}/.darglint
@@ -1,2 +1,0 @@
-[darglint]
-strictness = short

--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -5,3 +5,4 @@ max-line-length = 80
 max-complexity = 10
 docstring-convention = google
 per-file-ignores = tests/*:S101
+strictness = short


### PR DESCRIPTION
- Moved arguments from `.darglint` to `.flake8` and deleted `.darglint`
- Removed mentions of `.darglint` from the docs

Closes #518 
