### PR TITLE
Combine coverage data with GitHub Action

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -2284,6 +2284,7 @@ __ https://help.github.com/en/actions/automating-your-workflow-with-github-actio
    :ref:`tests <The tests session>`           Ubuntu                 3.8, 3.7, 3.6
    :ref:`tests <The tests session>`           Windows                3.8
    :ref:`tests <The tests session>`           macOS                  3.8
+   :ref:`coverage <The coverage session>`     Ubuntu                 3.8
    :ref:`docs-build <The docs-build session>` Ubuntu                 3.8
    ========================================== ====================== ===============
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -2203,6 +2203,7 @@ Workflows use the following GitHub Actions:
    ============================================ =========================================================
    `actions/cache`_                             Cache dependencies and build outputs
    `actions/checkout`_                          Check out the Git repository
+   `actions/download-artifact`_                 Download artifacts from workflows
    `actions/setup-python`_                      Set up workflows with a specific Python version
    `actions/upload-artifact`_                   Upload artifacts from workflows
    `codecov/codecov-action`_                    Upload coverage to Codecov
@@ -2213,6 +2214,7 @@ Workflows use the following GitHub Actions:
 
 .. _actions/cache: https://github.com/actions/cache
 .. _actions/checkout: https://github.com/actions/checkout
+.. _actions/download-artifact: https://github.com/actions/download-artifact
 .. _actions/setup-python: https://github.com/actions/setup-python
 .. _actions/upload-artifact: https://github.com/actions/upload-artifact
 .. _codecov/codecov-action: https://github.com/codecov/codecov-action
@@ -2303,8 +2305,9 @@ The Tests workflow uses the following GitHub Actions:
 
 - `actions/checkout`_ for checking out the Git repository
 - `actions/setup-python`_ for setting up the Python interpreter
+- `actions/download-artifact`_ to download the coverage data of each tests session
 - `actions/cache`_ for caching pre-commit environments
-- `actions/upload-artifact`_ to upload the generated documentation
+- `actions/upload-artifact`_ to upload the generated documentation and the coverage data of each tests session
 - `codecov/codecov-action`_ for uploading to Codecov_
 
 The Tests workflow is defined in ``.github/workflows/tests.yml``.

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -81,6 +81,7 @@ jobs:
           nox --force-color --python=${{ "{{" }} matrix.python-version {{ "}}" }}
 
       - name: Upload coverage data
+        if: always() && matrix.session == 'tests'
         uses: "actions/upload-artifact@v2"
         with:
           name: coverage-data

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -82,10 +82,10 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: "actions/upload-artifact@v2"
+        uses: "actions/upload-artifact@v2.2.0"
         with:
           name: coverage-data
-          path: {{ "${{ github.workspace }}/.coverage.*" }}
+          path: ".coverage.*"
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
@@ -122,7 +122,7 @@ jobs:
           nox --version
 
       - name: Download coverage data
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v2.0.5
         with:
           name: coverage-data
 

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -80,6 +80,12 @@ jobs:
         run: |
           nox --force-color --python=${{ "{{" }} matrix.python-version {{ "}}" }}
 
+      - name: Upload coverage data
+        uses: "actions/upload-artifact@v2"
+        with:
+          name: coverage-data
+          path: {{ "${{ github.workspace }}/.coverage.*" }}
+
       - name: Upload documentation
         if: matrix.session == 'docs-build'
         uses: actions/upload-artifact@v2
@@ -87,11 +93,45 @@ jobs:
           name: docs
           path: docs/_build
 
+  coverage:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2.3.2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2.1.2
+        with:
+          python-version: 3.8
+
+      - name: Upgrade pip
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt pip
+          pip --version
+
+      - name: Install Poetry
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt poetry
+          poetry --version
+
+      - name: Install Nox
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt nox
+          nox --version
+
+      - name: "Download coverage data"
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-data
+
+      - name: Combine coverage data and display human readable report
+        run: |
+          nox --force-color --session=coverage
+
       - name: Create coverage report
-        if: always() && matrix.session == 'tests'
         run: |
           nox --force-color --session=coverage -- xml
 
       - name: Upload coverage report
-        if: always() && matrix.session == 'tests'
         uses: codecov/codecov-action@v1.0.13

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt nox
           nox --version
 
-      - name: "Download coverage data"
+      - name: Download coverage data
         uses: actions/download-artifact@v2
         with:
           name: coverage-data

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -226,7 +226,8 @@ def tests(session: Session) -> None:
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:
-        session.notify("coverage")
+        if session.interactive:
+            session.notify("coverage")
 
 
 @nox.session


### PR DESCRIPTION
- In `tests` nox session, `coverage` session is automatically called only in interactive mode.
- In `tests` GA workflow, coverage data are saved as artefact for each entry in the matrix.
- In `tests` GA workflow, a `coverage`job is added to download from artefacts all coverage data, combine them and upload the report on codecov.
- Documentation update.

Closes #468 