### PR TITLE
Ignore RST201 for compatibility with Google-style docstrings

### DIFF
--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 select = B,B9,C,D,DAR,E,F,N,RST,S,W
-ignore = E203,E501,RST203,RST301,W503
+ignore = E203,E501,RST201,RST203,RST301,W503
 max-line-length = 80
 max-complexity = 10
 docstring-convention = google


### PR DESCRIPTION
This warning is triggered when a multi-line parameter description is surrounded by other parameters.

Closes #569 

See https://github.com/peterjc/flake8-rst-docstrings/issues/17 for details