### PR TITLE
Fix missing nox-poetry in Tests workflow

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Install Nox
         run: |
-          pip install --constraint=.github/workflows/constraints.txt nox
+          pip install --constraint=.github/workflows/constraints.txt nox nox-poetry
           nox --version
 
       - name: Download coverage data


### PR DESCRIPTION
Due to an oversight when merging #568 , `nox-poetry` (added in #570) was not installed in the new `coverage` job, leading to a `ModuleNotFoundError` during workflow runs (see https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/runs/1228484769).