### PR TITLE
Replace `master` by `$default-branch` in Release workflow

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - $default-branch
 
 jobs:
   release:


### PR DESCRIPTION
Closes #561 

See https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/327