### PR TITLE
Support `main` branch in Release workflow

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches:
+      - main
       - master
 
 jobs:


### PR DESCRIPTION
The Release workflow now supports both `main` and `master` as names for the default repository branch. Since October 1, 2020, new GitHub repositories are created using `main` as the default branch name. See https://github.com/github/renaming for details.

We continue to support the legacy name `master` for now. This allows existing projects to receive changes from the template, without requiring them to migrate their default branch beforehand.

Closes #561 
