### PR TITLE
Support Python 3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Features
 - Check documentation examples with xdoctest_
 - Generate API documentation with autodoc_ and napoleon_
 
-The template supports Python 3.6, 3.7, and 3.8.
+The template supports Python 3.6, 3.7, 3.8, and 3.9.
 
 .. features-end
 
@@ -121,7 +121,7 @@ Install Nox_ and nox-poetry_:
 
 pipx_ is preferred, but you can also install with ``pip install --user``.
 
-It is recommended to set up Python 3.6, 3.7, and 3.8 using pyenv_.
+It is recommended to set up Python 3.6, 3.7, 3.8, and 3.9 using pyenv_.
 
 
 Creating a project

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -145,13 +145,14 @@ using one of the commands listed in the
 __ https://github.com/pyenv/pyenv/wiki/Common-build-problems
 
 Install the latest point release of every supported Python version.
-This project template supports Python 3.6, 3.7, and 3.8.
+This project template supports Python 3.6, 3.7, 3.8, and 3.9.
 
 .. code:: console
 
    $ pyenv install 3.6.12
    $ pyenv install 3.7.9
    $ pyenv install 3.8.6
+   $ pyenv install 3.9.0
 
 After creating your project (see :ref:`below <Creating a project>`),
 you can make these Python versions accessible in the project directory,
@@ -159,7 +160,7 @@ using the following command:
 
 .. code:: console
 
-   $ pyenv local 3.8.6 3.7.9 3.6.12
+   $ pyenv local 3.9.0 3.8.6 3.7.9 3.6.12
 
 The first version listed is the one used when you type plain ``python``.
 Every version can be used by invoking ``python<major.minor>``.
@@ -845,9 +846,10 @@ and easily switch between them:
    $ poetry env use 3.6
    $ poetry env use 3.7
    $ poetry env use 3.8
+   $ poetry env use 3.9
 
 Only one Poetry environment can be active at any time.
-Note that ``3.8`` comes last,
+Note that ``3.9`` comes last,
 to ensure that the current Python release is the active environment.
 Install your package with ``poetry install`` into each environment after creating it.
 
@@ -1037,7 +1039,7 @@ For example, the following may be more practical during development
 
 .. code:: console
 
-   $ nox -rs tests-3.8
+   $ nox -rs tests -p 3.9
 
 .. _--reuse-existing-virtualenvs: https://nox.thea.codes/en/stable/usage.html#re-using-virtualenvs
 
@@ -1056,15 +1058,15 @@ The following table gives an overview of the available Nox sessions:
    ========================================== ===================================== ================== =========
    Session                                    Description                           Python              Default
    ========================================== ===================================== ================== =========
-   :ref:`coverage <The coverage session>`     Report coverage with Coverage.py_     ``3.8``
+   :ref:`coverage <The coverage session>`     Report coverage with Coverage.py_     ``3.9``
    :ref:`docs <The docs session>`             Build and serve Sphinx_ documentation ``3.8``
    :ref:`docs-build <The docs-build session>` Build Sphinx_ documentation           ``3.8``                ✓
-   :ref:`mypy <The mypy session>`             Type-check with mypy_                 ``3.6`` … ``3.8``      ✓
-   :ref:`pre-commit <The pre-commit session>` Lint with pre-commit_                 ``3.8``                ✓
-   :ref:`safety <The safety session>`         Scan dependencies with Safety_        ``3.8``                ✓
-   :ref:`tests <The tests session>`           Run tests with pytest_                ``3.6`` … ``3.8``      ✓
-   :ref:`typeguard <The typeguard session>`   Type-check with Typeguard_            ``3.6`` … ``3.8``      ✓
-   :ref:`xdoctest <The xdoctest session>`     Run examples with xdoctest_           ``3.6`` … ``3.8``
+   :ref:`mypy <The mypy session>`             Type-check with mypy_                 ``3.6`` … ``3.9``      ✓
+   :ref:`pre-commit <The pre-commit session>` Lint with pre-commit_                 ``3.9``                ✓
+   :ref:`safety <The safety session>`         Scan dependencies with Safety_        ``3.9``                ✓
+   :ref:`tests <The tests session>`           Run tests with pytest_                ``3.6`` … ``3.9``      ✓
+   :ref:`typeguard <The typeguard session>`   Type-check with Typeguard_            ``3.6`` … ``3.9``      ✓
+   :ref:`xdoctest <The xdoctest session>`     Run examples with xdoctest_           ``3.6`` … ``3.9``
    ========================================== ===================================== ================== =========
 
 
@@ -1131,7 +1133,7 @@ using the current stable release of Python:
 
 .. code:: console
 
-   $ nox --session=mypy-3.8
+   $ nox --session=mypy --python=3.9
 
 Use the separator ``--`` to pass additional options and arguments to ``mypy``.
 For example, the following command type-checks only the ``__main__`` module:
@@ -1214,7 +1216,7 @@ using the current stable release of Python:
 
 .. code:: console
 
-   $ nox --session=tests-3.8
+   $ nox --session=tests --python=3.9
 
 Use the separator ``--`` to pass additional options to ``pytest``.
 For example, the following command runs only the test case ``test_main_succeeds``:
@@ -1307,7 +1309,7 @@ with the current stable release of Python:
 
 .. code:: console
 
-   $ nox --session=typeguard-3.8
+   $ nox --session=typeguard --python=3.9
 
 Use the separator ``--`` to pass additional options and arguments to pytest.
 For example, the following command runs only tests for the ``__main__`` module:
@@ -1350,7 +1352,7 @@ using the current stable release of Python:
 
 .. code:: console
 
-   $ nox --session=xdoctest-3.8
+   $ nox --session=xdoctest --python=3.9
 
 By default, the Nox session uses the ``all`` subcommand to run all examples.
 You can also list examples using the ``list`` subcommand,
@@ -2213,18 +2215,18 @@ __ https://help.github.com/en/actions/automating-your-workflow-with-github-actio
    :class: hypermodern-table
    :widths: auto
 
-   ========================================== ====================== ===============
+   ========================================== ====================== ==================
    Nox session                                Platform               Python versions
-   ========================================== ====================== ===============
-   :ref:`pre-commit <The pre-commit session>` Ubuntu                 3.8
-   :ref:`safety <The safety session>`         Ubuntu                 3.8
-   :ref:`mypy <The mypy session>`             Ubuntu                 3.8, 3.7, 3.6
-   :ref:`tests <The tests session>`           Ubuntu                 3.8, 3.7, 3.6
-   :ref:`tests <The tests session>`           Windows                3.8
-   :ref:`tests <The tests session>`           macOS                  3.8
-   :ref:`coverage <The coverage session>`     Ubuntu                 3.8
+   ========================================== ====================== ==================
+   :ref:`pre-commit <The pre-commit session>` Ubuntu                 3.9
+   :ref:`safety <The safety session>`         Ubuntu                 3.9
+   :ref:`mypy <The mypy session>`             Ubuntu                 3.9, 3.8, 3.7, 3.6
+   :ref:`tests <The tests session>`           Ubuntu                 3.9, 3.8, 3.7, 3.6
+   :ref:`tests <The tests session>`           Windows                3.9
+   :ref:`tests <The tests session>`           macOS                  3.9
+   :ref:`coverage <The coverage session>`     Ubuntu                 3.9
    :ref:`docs-build <The docs-build session>` Ubuntu                 3.8
-   ========================================== ====================== ===============
+   ========================================== ====================== ==================
 
 The workflow uploads the generated documentation as a `workflow artifact`__.
 Building the documentation only serves the purpose of catching issues in pull requests.

--- a/{{cookiecutter.project_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2.1.3
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Upgrade pip
         run: |

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -12,17 +12,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { python-version: 3.8, os: ubuntu-latest, session: "pre-commit" }
-          - { python-version: 3.8, os: ubuntu-latest, session: "safety" }
+          - { python-version: 3.9, os: ubuntu-latest, session: "pre-commit" }
+          - { python-version: 3.9, os: ubuntu-latest, session: "safety" }
+          - { python-version: 3.9, os: ubuntu-latest, session: "mypy" }
           - { python-version: 3.8, os: ubuntu-latest, session: "mypy" }
           - { python-version: 3.7, os: ubuntu-latest, session: "mypy" }
           - { python-version: 3.6, os: ubuntu-latest, session: "mypy" }
+          - { python-version: 3.9, os: ubuntu-latest, session: "tests" }
           - { python-version: 3.8, os: ubuntu-latest, session: "tests" }
           - { python-version: 3.7, os: ubuntu-latest, session: "tests" }
           - { python-version: 3.6, os: ubuntu-latest, session: "tests" }
-          - { python-version: 3.8, os: windows-latest, session: "tests" }
-          - { python-version: 3.8, os: macos-latest, session: "tests" }
-          - { python-version: 3.8, os: ubuntu-latest, session: "typeguard" }
+          - { python-version: 3.9, os: windows-latest, session: "tests" }
+          - { python-version: 3.9, os: macos-latest, session: "tests" }
+          - { python-version: 3.9, os: ubuntu-latest, session: "typeguard" }
           - { python-version: 3.8, os: ubuntu-latest, session: "docs-build" }
 
     env:
@@ -101,10 +103,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v2.3.2
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2.1.2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Upgrade pip
         run: |

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -10,7 +10,7 @@ from nox.sessions import Session
 
 
 package = "{{cookiecutter.package_name}}"
-python_versions = ["3.8", "3.7", "3.6"]
+python_versions = ["3.9", "3.8", "3.7", "3.6"]
 nox.options.sessions = (
     "pre-commit",
     "safety",
@@ -72,7 +72,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
         hook.write_text("\n".join(lines))
 
 
-@nox.session(name="pre-commit", python="3.8")
+@nox.session(name="pre-commit", python="3.9")
 def precommit(session: Session) -> None:
     """Lint using pre-commit."""
     args = session.posargs or ["run", "--all-files", "--show-diff-on-failure"]
@@ -94,7 +94,7 @@ def precommit(session: Session) -> None:
         activate_virtualenv_in_precommit_hooks(session)
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = nox_poetry.export_requirements(session)

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
This PR adds support for Python 3.9.

Closes #14 

#### Package metadata

- Add trove classifier for Python 3.9.

#### Nox sessions

- Add Python 3.9 support to `mypy`, `tests`, `typeguard`, and `xdoctest`
- Replace Python 3.8 by Python 3.9 in `pre-commit` and `safety`
- Keep Python 3.8 for `docs` and `docs-build` pending https://github.com/readthedocs/readthedocs.org/issues/7554
- The `coverage` session does not use a specific Python version.

#### Release workflow

- Replace Python 3.8 by Python 3.9 in the Release workflow.

#### Tests workflow

Support Python 3.9 in these jobs:

- tests / mypy
- tests / tests

Replace Python 3.8 by 3.9 in these jobs:

- coverage
- tests / pre-commit
- tests / safety
- tests / tests (Windows)
- tests / tests (Mac)
- tests / typeguard

Keep Python 3.8 in this job (see above):

- tests / docs-build

(The runner OS is Ubuntu unless noted otherwise.)
