### PR TITLE
Enable Nox session for xdoctest by default

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1066,7 +1066,7 @@ The following table gives an overview of the available Nox sessions:
    :ref:`safety <The safety session>`         Scan dependencies with Safety_        ``3.9``                ✓
    :ref:`tests <The tests session>`           Run tests with pytest_                ``3.6`` … ``3.9``      ✓
    :ref:`typeguard <The typeguard session>`   Type-check with Typeguard_            ``3.6`` … ``3.9``      ✓
-   :ref:`xdoctest <The xdoctest session>`     Run examples with xdoctest_           ``3.6`` … ``3.9``
+   :ref:`xdoctest <The xdoctest session>`     Run examples with xdoctest_           ``3.6`` … ``3.9``      ✓
    ========================================== ===================================== ================== =========
 
 

--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
           - { python-version: 3.9, os: windows-latest, session: "tests" }
           - { python-version: 3.9, os: macos-latest, session: "tests" }
           - { python-version: 3.9, os: ubuntu-latest, session: "typeguard" }
+          - { python-version: 3.9, os: ubuntu-latest, session: "xdoctest" }
           - { python-version: 3.8, os: ubuntu-latest, session: "docs-build" }
 
     env:

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -17,6 +17,7 @@ nox.options.sessions = (
     "mypy",
     "tests",
     "typeguard",
+    "xdoctest",
     "docs-build",
 )
 


### PR DESCRIPTION
This PR includes the Nox session for [xdoctest] in local checks and in the Tests workflow. Previously, the session had to be enabled explicitly using the `--session` option, and wasn't run in CI at all. The session runs locally for all supported major Python versions, and on Python 3.9 during CI.

Closes #251 

[xdoctest]: https://xdoctest.readthedocs.io/en/latest/