### PR TITLE
Support packages whose name does not match the project name

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.rst"
 homepage = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}"
 repository = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}"
 documentation = "https://{{cookiecutter.project_name}}.readthedocs.io"
-{%- if cookiecutter.package_name != cookiecutter.project_name.replace('-', '_') -%}
+{% if cookiecutter.package_name != cookiecutter.project_name.replace('-', '_') -%}
 packages = [
     { include = "{{cookiecutter.package_name}}", from = "src" },
 ]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://{{cookiecutter.project_name}}.readthedocs.io"
 packages = [
     { include = "{{cookiecutter.package_name}}", from = "src" },
 ]
-{%- endif %}
+{% endif -%}
 classifiers = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.rst"
 homepage = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}"
 repository = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}"
 documentation = "https://{{cookiecutter.project_name}}.readthedocs.io"
-{%+ if cookiecutter.package_name != cookiecutter.project_name.replace('-', '_') -%}
+{%- if cookiecutter.package_name != cookiecutter.project_name.replace('-', '_') -%}
 packages = [
     { include = "{{cookiecutter.package_name}}", from = "src" },
 ]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -8,6 +8,11 @@ readme = "README.rst"
 homepage = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}"
 repository = "https://github.com/{{cookiecutter.github_user}}/{{cookiecutter.project_name}}"
 documentation = "https://{{cookiecutter.project_name}}.readthedocs.io"
+{%+ if cookiecutter.package_name != cookiecutter.project_name.replace('-', '_') -%}
+packages = [
+    { include = "{{cookiecutter.package_name}}", from = "src" },
+]
+{%- endif %}
 classifiers = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
if the package name and project name are not similar (more than `-` replaced by `_`), a `package` key will be added in `pyproject.toml` file.

Example: 
```toml
packages = [
    { include = "package_name", from = "src" },
]
```

fix: #546 