### PR TITLE
Change to standalone build backend  (PEP-517)

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -61,5 +61,5 @@ show_missing = true
 fail_under = 100
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The `[build-system]` section of `pyproject.toml` can be changed as of Poetry >= 1.1.0 to be a standalone backend. This updates the section to the recommended build backend to poetry-core.

More details in Poetry's [announcement](https://python-poetry.org/blog/announcing-poetry-1-1-0.html) and the [poetry-core](https://github.com/python-poetry/poetry-core) project.

---

Closes #635