### PR TITLE
Update prettier hook to new pre-commit repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-added-large-files
-  - repo: https://github.com/prettier/prettier
+  - repo: https://github.com/prettier/pre-commit
     rev: 2.1.2
     hooks:
       - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
       - id: trailing-whitespace
       - id: check-added-large-files
   - repo: https://github.com/prettier/pre-commit
-    rev: 2.1.2
+    rev: v2.1.2
     hooks:
       - id: prettier

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -46,6 +46,6 @@ repos:
         types: [text]
         stages: [commit, push, manual]
   - repo: https://github.com/prettier/pre-commit
-    rev: 2.1.2
+    rev: v2.1.2
     hooks:
       - id: prettier

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         language: system
         types: [text]
         stages: [commit, push, manual]
-  - repo: https://github.com/prettier/prettier
+  - repo: https://github.com/prettier/pre-commit
     rev: 2.1.2
     hooks:
       - id: prettier


### PR DESCRIPTION
[Prettier has moved its pre-commit support](https://github.com/prettier/prettier/pull/8937) to [github.com/prettier/pre-commit](https://github.com/prettier/pre-commit).

Drafting this PR to also test if it will fix the failing actions on Windows.

Closes #640