### PR TITLE
Upgrade Ubuntu version in guide

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -80,7 +80,7 @@ You need a recent Linux, Unix, or Mac system with
 bash_, curl_, and git_.
 
 On Windows 10, enable the `Windows Subsystem for Linux`_ (WSL) and
-install the Ubuntu 18.04 LTS distribution.
+install the Ubuntu 20.04 LTS distribution.
 Open Ubuntu from the Start Menu, and
 install additional packages using the following commands:
 


### PR DESCRIPTION
Upgrade Ubuntu version in Windows Subsystem for Linux section of the guide to 20.04. We might consider just leaving the version out of the guide to prevent it from needing to be periodically upgraded.

Closes #613 