### PR TITLE
Release 2020.11.15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
 
 .. code:: console
 
-   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2020.10.15
+   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2020.11.15
 
 
 Features
@@ -134,7 +134,7 @@ Generate a Python project:
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2020.10.15"
+     --checkout="2020.11.15"
 
 Change to the root directory of your new project,
 and create a Git repository:

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -63,9 +63,9 @@ The |HPC| has a monthly release cadence while in alpha status.
 Releases happen on the 15th of every month.
 We use `Calendar Versioning`_ with a ``YYYY.MM.DD`` versioning scheme.
 
-The current stable release is `2020.10.15`_.
+The current stable release is `2020.11.15`_.
 
-.. _2020.10.15: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2020.10.15
+.. _2020.11.15: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2020.11.15
 
 
 .. _Installation:
@@ -220,12 +220,12 @@ Creating a project
 
 Create a project from this template
 by pointing Cookiecutter to its `GitHub repository <Hypermodern Python Cookiecutter_>`__.
-Use the ``--checkout`` option with the `current stable release <2020.10.15_>`__:
+Use the ``--checkout`` option with the `current stable release <2020.11.15_>`__:
 
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2020.10.15"
+     --checkout="2020.11.15"
 
 Cookiecutter downloads the template,
 and asks you a series of questions about project variables,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Usage
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2020.10.15"
+     --checkout="2020.11.15"
 
 
 Features


### PR DESCRIPTION
## Overview of Changes

This section highlights the main changes brought by this release.

- **Manage GitHub labels using a YAML configuration file** (thanks @oncleben31)

  GitHub labels can now be managed using the `.github/labels.yml` configuration file, using the [GitHub Labeler] action. Labels are used, among other things, to categorize pull requests for the release notes. Thanks to the new Labeler workflow, it is no longer necessary to create GitHub labels manually after generating a project.
  
[GitHub Labeler]: https://github.com/marketplace/actions/github-labeler

- **Support packages whose name does not match the project name** (thanks @oncleben31)

  By default, Poetry only includes packages if their name matches the configured project name. If a custom `package_name` is specified on project generation, the package must be listed explicitly in the `pyproject.toml` file. This is now done automatically on project generation.

- **Use standalone build backend for PEP 517 builds** (thanks @paw-lu)

  Generated projects now use the new standalone build backend introduced by Poetry 1.1. This greatly speeds up [PEP 517] isolated builds, because they no longer need to install the full Poetry CLI to build the package.

[PEP 517]: https://www.python.org/dev/peps/pep-0517/

Read on for a complete list of changes.

## Changes

This section lists changes affecting generated projects.

## :rocket: Features

* Add GitHub Labeler Action to manage project labels automatically (#634) @oncleben31
* Support packages whose name does not match the project name (#631) @oncleben31
* Change to standalone build backend (PEP-517) (#638) @paw-lu

## :beetle: Fixes

* Update prettier hook to new pre-commit repo (#639) @paw-lu

## :package: Dependencies

* Bump actions/cache from v2.1.2 to v2.1.3 (#668) @cjolowicz
* Bump codecov/codecov-action from v1.0.13 to v1.0.14 (#650) @cjolowicz
* Bump pip from 20.2.3 to 20.2.4 in /.github/workflows (#651) @cjolowicz
* Bump pre-commit from 2.7.1 to 2.8.2 (#658) @cjolowicz
* Bump pre-commit-hooks from 3.2.0 to 3.3.0 (#654) @cjolowicz
* Bump pygments from 2.7.1 to 2.7.2 (#656) @cjolowicz
* Bump pytest from 6.1.1 to 6.1.2 (#657) @cjolowicz
* Bump regex from 2020.6.8 to 2020.10.28 (#667) @cjolowicz
* Bump release-drafter/release-drafter from v5.11.0 to v5.12.1 (#653) @cjolowicz
* Bump reorder-python-imports from 2.3.5 to 2.3.6 (#663) @cjolowicz
* Bump sphinx from 3.2.1 to 3.3.0 (#664) @cjolowicz
* Bump sphinx from 3.2.1 to 3.3.0 in /docs (#659) @cjolowicz
* Bump sphinx from 3.3.0 to 3.3.1 (#671) @cjolowicz
* Bump sphinx from 3.3.0 to 3.3.1 in /docs (#670) @cjolowicz
* Bump virtualenv from 20.0.35 to 20.1.0 in /.github/workflows (#655) @cjolowicz
* Update actions/checkout requirement to v2.3.4 (#662) @cjolowicz

## Changes to the Cookiecutter

This section lists changes to the Cookiecutter that don't affect generated projects.

## :beetle: Fixes

* Update prettier hook to new pre-commit repo (#639) @paw-lu

## :books: Documentation

* Upgrade Ubuntu version in guide (#642) @paw-lu

## :package: Dependencies

* Bump actions/cache from v2.1.2 to v2.1.3 (#666) @dependabot
* Bump actions/checkout from v2.3.3 to v2.3.4 (#661) @dependabot
* Bump pip from 20.2.3 to 20.2.4 in /.github/workflows (#628) @dependabot
* Bump release-drafter/release-drafter from v5.11.0 to v5.12.0 (#630) @dependabot
* Bump release-drafter/release-drafter from v5.12.0 to v5.12.1 (#632) @dependabot
* Bump sphinx from 3.2.1 to 3.3.0 in /docs (#647) @dependabot
* Bump sphinx from 3.3.0 to 3.3.1 in /docs (#669) @dependabot
* Bump virtualenv from 20.0.34 to 20.0.35 in /.github/workflows (#627) @dependabot
* Bump virtualenv from 20.0.35 to 20.1.0 in /.github/workflows (#636) @dependabot
* Pin pre-commit to 2.8.2 in .github/workflows/constraints.txt (#660) @cjolowicz
