### PR TITLE
Add tools to automate Cookiecutter releases

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -5,6 +5,33 @@ import shutil
 import nox
 from nox.sessions import Session
 
+nox.options.sessions = ["docs"]
+owner, repository = "cjolowicz", "cookiecutter-hypermodern-python"
+labels = "cookiecutter", "documentation"
+bump_paths = "README.rst", "docs/guide.rst", "docs/index.rst", "docs/quickstart.rst"
+
+
+@nox.session(name="prepare-release")
+def prepare_release(session: Session) -> None:
+    """Prepare a GitHub release."""
+    args = [
+        f"--owner={owner}",
+        f"--repository={repository}",
+        *[f"--bump={path}" for path in bump_paths],
+        *[f"--label={label}" for label in labels],
+        *session.posargs,
+    ]
+    session.install("click", "github3")
+    session.run("tools/prepare-github-release.py", *args, external=True)
+
+
+@nox.session(name="publish-release")
+def publish_release(session: Session) -> None:
+    """Publish a GitHub release."""
+    args = [f"--owner={owner}", f"--repository={repository}", *session.posargs]
+    session.install("click", "github3")
+    session.run("tools/publish-github-release.py", *args, external=True)
+
 
 @nox.session
 def docs(session: Session) -> None:

--- a/tools/prepare-github-release.py
+++ b/tools/prepare-github-release.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+import datetime
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from typing import Iterable
+from typing import List
+from typing import Optional
+
+import click
+import github3
+
+
+def git(*args: str, **kwargs: Any) -> str:
+    process = subprocess.call(
+        ["git", *args], check=True, capture_output=True, text=True
+    )
+    return process.stdout
+
+
+def replace_text(path: Path, old: str, new: str):
+    text = path.read_text()
+    text.replace(old, new)
+    path.write_text(text)
+
+
+def prepare_release(
+    *,
+    owner: str,
+    repository_name: str,
+    token: str,
+    tag: str,
+    remote: str,
+    base: str,
+    bump_paths: List[Path],
+    label_names: List[str],
+) -> None:
+    branch = f"release-{tag}"
+    title = f"Release {tag}"
+    oldtag = git("describe", "--tags", "--abbrev=0").strip()
+
+    git("switch", f"--create={branch}", base)
+
+    for path in bump_paths:
+        replace_text(path, oldtag, tag)
+        git("add", str(path))
+
+    git("commit", f"--message={title}")
+    git("push", "--set-upstream", remote, branch)
+
+    click.echo(f"pushed {branch}")
+
+    github = github3.login(token=token)
+    repository = github.repository(owner, repository_name)
+
+    try:
+        [release] = [release for release in repository.releases() if release.draft]
+    except ValueError:
+        raise RuntimeError("there should be exactly one draft release")
+
+    pull_request = repository.create_pull(
+        title=title,
+        base=base,
+        head=f"{owner}:{branch}",
+        body=release.body,
+    )
+
+    click.echo(f"opened #{pull_request.number}")
+
+    pull_request = repository.pull_request(pull_request.number)
+    labels = pull_request.issue().add_labels(*label_names)
+
+    for name in label_names:
+        if name not in {label.name for label in labels}:
+            raise RuntimeError(f"label {name} missing from #{pull_request.number}")
+
+    click.echo(f"added labels {', '.join(label_names)} to #{pull_request.number}")
+
+
+@click.command()
+@click.option(
+    "--owner",
+    metavar="USER",
+    required=True,
+    envvar="GITHUB_USER",
+    help="GitHub username",
+)
+@click.option(
+    "--repository",
+    metavar="REPO",
+    required=True,
+    envvar="GITHUB_REPOSITORY",
+    help="GitHub repository",
+)
+@click.option(
+    "--token",
+    metavar="TOKEN",
+    required=True,
+    envvar="GITHUB_TOKEN",
+    help="GitHub API token",
+)
+@click.option(
+    "--remote",
+    metavar="REMOTE",
+    default="origin",
+    help="remote for GitHub repository",
+)
+@click.option(
+    "--base",
+    metavar="BRANCH",
+    default="master",
+    help="default branch of the GitHub repository",
+)
+@click.option(
+    "--bump",
+    metavar="FILE",
+    multiple=True,
+    help="bump the version in these files (may be specified multiple times)",
+)
+@click.option(
+    "labels",
+    "--label",
+    metavar="LABEL",
+    multiple=True,
+    help="labels for the pull request (may be specified multiple times)",
+)
+@click.argument("tag")
+def main(
+    owner: str,
+    repository: str,
+    token: str,
+    remote: str,
+    base: str,
+    bump: Iterable[str],
+    labels: Iterable[str],
+    tag: Optional[str],
+) -> None:
+    """Open a pull request to release this project.
+
+    If no release tag is specified, YYYY.MM.DD is used with the current date.
+    There must be a single draft release. This script pushes a branch
+    `release-TAG` and opens a pull request for it taking the pull request
+    description from the draft release notes. The branch contains a single
+    commit which updates the version number in the documentation.
+    """
+
+    if tag is None:
+        today = datetime.date.today()
+        tag = f"{today:%Y.%-m.%-d}"
+
+    try:
+        prepare_release(
+            owner=owner,
+            repository_name=repository,
+            token=token,
+            remote=remote,
+            base=base,
+            bump_paths=[Path(path) for path in bump],
+            label_names=list(labels),
+            tag=tag,
+        )
+    except Exception as error:
+        click.secho(f"error: {error}", fg="red")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main(prog_name="prepare-github-release")

--- a/tools/publish-github-release.py
+++ b/tools/publish-github-release.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+import datetime
+import sys
+from typing import Optional
+
+import click
+import github3
+
+
+def publish_release(*, owner: str, repository_name: str, token: str, tag: str) -> None:
+    github = github3.login(token=token)
+    repository = github.repository(owner, repository_name)
+
+    try:
+        [pull_request] = list(repository.pull_requests(head=f"{owner}:release-{tag}"))
+    except ValueError:
+        raise RuntimeError(
+            f"there should be exactly one pull request for {owner}:release-{tag}"
+        )
+
+    pull_request = repository.pull_request(pull_request.number)
+
+    try:
+        [*_, commit] = pull_request.commits()
+    except ValueError:
+        raise RuntimeError(
+            f"there should be at least one commit associated with #{pull_request.number}"
+        )
+
+    try:
+        [release] = [release for release in repository.releases() if release.draft]
+    except ValueError:
+        raise RuntimeError("there should be exactly one draft release")
+
+    if commit.status.state != "success":
+        raise RuntimeError(f"checks for #{pull_request.number} have failed")
+
+    if pull_request.is_merged():
+        raise RuntimeError(f"#{pull_request.number} has been merged already")
+
+    if not pull_request.mergeable:
+        raise RuntimeError(f"#{pull_request.number} is not mergeable")
+
+    title = f"{pull_request.title} (#{pull_request.number})"
+
+    if not pull_request.merge(commit_title=title, merge_method="squash"):
+        raise RuntimeError(f"cannot merge #{pull_request.number}")
+
+    if not pull_request.is_merged():
+        raise RuntimeError(f"#{pull_request.number} was not merged")
+
+    click.echo(f"merged #{pull_request.number}")
+
+    branch = repository.ref(f"heads/{pull_request.head.ref}")
+
+    if not branch.delete():
+        raise RuntimeError(f"cannot remove {branch.ref}")
+
+    click.echo(f"removed {branch.ref}")
+
+    if not release.edit(
+        tag_name=tag,
+        name=tag,
+        body=pull_request.body,
+        draft=False,
+        prerelease=False,
+    ):
+        raise RuntimeError(f"cannot publish {release.name}")
+
+    click.echo(f"published {release.name}")
+
+
+@click.command()
+@click.option(
+    "--owner",
+    metavar="USER",
+    required=True,
+    envvar="GITHUB_USER",
+    help="GitHub username",
+)
+@click.option(
+    "--repository",
+    metavar="REPO",
+    required=True,
+    envvar="GITHUB_REPOSITORY",
+    help="GitHub repository",
+)
+@click.option(
+    "--token",
+    metavar="TOKEN",
+    required=True,
+    envvar="GITHUB_TOKEN",
+    help="GitHub API token",
+)
+@click.argument("tag")
+def main(owner: str, repository: str, token: str, tag: Optional[str]) -> None:
+    """Publish a GitHub release for this project.
+
+    If no release tag is specified, YYYY.MM.DD is used with the current date.
+    There must be a single draft release, as well as a pull request for a
+    branch `release-TAG`. This script merges the pull request and publishes
+    the release, taking the release notes from the pull request description.
+    """
+    if tag is None:
+        today = datetime.date.today()
+        tag = f"{today:%Y.%-m.%-d}"
+
+    try:
+        publish_release(
+            owner=owner,
+            repository_name=repository,
+            token=token,
+            tag=tag,
+        )
+    except Exception as error:
+        click.secho(f"error: {error}", fg="red")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main(prog_name="publish-github-release")


### PR DESCRIPTION
The intended workflow is as follows:

```sh
export GITHUB_TOKEN=<secret>

nox -rs prepare-release
# Edit pull request description on GitHub...
nox -rs publish-release
```

Releases require some changes to the documentation, and we always hand-edit the draft release before publishing. So we cannot release the Cookiecutter simply by publishing the automated draft release. Instead, the `prepare-release` session creates a PR with all required changes, and copies the release notes from the draft release into the pull request description. The `publish-release` session merges the PR, copies the release notes back into the draft release, and publishes the release.

There is a race condition with Release Drafter here, which will also attempt to update the draft release when the PR is merged. Unfortunately, there is no obvious way to skip the workflow when the release branch is merged. Under normal conditions, the Nox session will have published the release before the Release Drafter workflow spins up, so the workflow will simply create a new empty draft release. IIUC setting the release notes and publishing the release happens in a single transaction, so we're not going to publish a draft release without the edits from the pull request. In the unlikely case that the workflow updates the draft release first, the Nox session will overwrite its changes, and the results will be the same.