### PR TITLE
Release 2021.1.29

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
 
 .. code:: console
 
-   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2020.11.15
+   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.1.29
 
 
 Features

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -63,9 +63,9 @@ The |HPC| has a monthly release cadence while in alpha status.
 Releases happen on the 15th of every month.
 We use `Calendar Versioning`_ with a ``YYYY.MM.DD`` versioning scheme.
 
-The current stable release is `2020.11.15`_.
+The current stable release is `2021.1.29`_.
 
-.. _2020.11.15: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2020.11.15
+.. _2021.1.29: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.1.29
 
 
 .. _Installation:
@@ -220,12 +220,12 @@ Creating a project
 
 Create a project from this template
 by pointing Cookiecutter to its `GitHub repository <Hypermodern Python Cookiecutter_>`__.
-Use the ``--checkout`` option with the `current stable release <2020.11.15_>`__:
+Use the ``--checkout`` option with the `current stable release <2021.1.29_>`__:
 
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2020.11.15"
+     --checkout="2021.1.29"
 
 Cookiecutter downloads the template,
 and asks you a series of questions about project variables,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Usage
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2020.11.15"
+     --checkout="2021.1.29"
 
 
 Features

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Generate a Python project:
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2020.11.15"
+     --checkout="2021.1.29"
 
 Change to the root directory of your new project,
 and create a Git repository:


### PR DESCRIPTION
## Overview of Changes

This is a maintenance release.

## Changes

This section lists changes affecting generated projects.

### :package: Dependencies

* Bump actions/download-artifact from v2.0.5 to v2.0.6 (#680) @cjolowicz
* Bump actions/download-artifact from v2.0.6 to v2.0.8 (#727) @cjolowicz
* Bump actions/setup-python from v2.1.4 to v2.2.1 (#748) @cjolowicz
* Bump actions/upload-artifact from v2.2.0 to v2.2.1 (#681) @cjolowicz
* Bump actions/upload-artifact from v2.2.1 to v2.2.2 (#752) @cjolowicz
* Bump codecov/codecov-action from v1.0.14 to v1.0.15 (#682) @cjolowicz
* Bump codecov/codecov-action from v1.0.15 to v1.2.1 (#725) @cjolowicz
* Bump coverage from 5.3 to 5.3.1 (#743) @cjolowicz
* Bump coverage from 5.3.1 to 5.4 (#744) @cjolowicz
* Bump crazy-max/ghaction-github-labeler from v3.1.0 to v3.1.1 (#704) @cjolowicz
* Bump darglint from 1.5.5 to 1.5.8 (#685) @cjolowicz
* Bump flake8-bugbear from 20.1.4 to 20.11.1 (#686) @cjolowicz
* Bump mypy from 0.790 to 0.800 (#751) @cjolowicz
* Bump nox from 2020.8.22 to 2020.12.31 in /.github/workflows (#713) @cjolowicz
* Bump nox-poetry from 0.5.0 to 0.7.1 in /.github/workflows (#721) @cjolowicz
* Bump pip from 20.2.4 to 21.0 in /.github/workflows (#739) @cjolowicz
* Bump poetry from 1.1.2 to 1.1.4 in /.github/workflows (#733) @cjolowicz
* Bump pre-commit from 2.8.2 to 2.9.3 (#732) @cjolowicz
* Bump pre-commit from 2.9.3 to 2.10.0 (#753) @cjolowicz
* Bump pre-commit-hooks from 3.3.0 to 3.4.0 (#749) @cjolowicz
* Bump py from 1.9.0 to 1.10.0 (#741) @cjolowicz
* Bump pygments from 2.7.2 to 2.7.4 (#723) @cjolowicz
* Bump pytest from 6.1.2 to 6.2.2 (#742) @cjolowicz
* Bump release-drafter/release-drafter from v5.12.1 to v5.13.0 (#728) @cjolowicz
* Bump safety from 1.9.0 to 1.10.3 (#746) @cjolowicz
* Bump sphinx from 3.3.1 to 3.4.3 (#754) @cjolowicz
* Bump sphinx from 3.3.1 to 3.4.3 in /docs (#724) @cjolowicz
* Bump sphinx-rtd-theme from 0.5.0 to 0.5.1 (#745) @cjolowicz
* Bump sphinx-rtd-theme from 0.5.0 to 0.5.1 in /docs (#726) @cjolowicz
* Bump typeguard from 2.9.1 to 2.10.0 (#652) @cjolowicz
* Bump virtualenv from 20.1.0 to 20.2.1 in /.github/workflows (#684) @cjolowicz
* Bump virtualenv from 20.2.1 to 20.4.0 in /.github/workflows (#740) @cjolowicz
* Bump xdoctest from 0.15.0 to 0.15.2 (#747) @cjolowicz
* Bump xdoctest from 0.15.2 to 0.15.3 (#755) @cjolowicz

## Changes to the Cookiecutter

This section lists changes to the Cookiecutter that don't affect generated projects.

### :construction_worker: Continuous Integration

* Add tools to automate Cookiecutter releases (#674) @cjolowicz
<!--
* Revert "Use cruft to update the Cookiecutter instance" (#757) @cjolowicz
* Use cruft to update the Cookiecutter instance (#756) @cjolowicz
-->

### :books: Documentation

* Remove Quickstart from README (#673) @cjolowicz

### :package: Dependencies

* Bump actions/setup-python from v2.1.4 to v2.2.0 (#705) @dependabot
* Bump actions/setup-python from v2.2.0 to v2.2.1 (#707) @dependabot
* Bump crazy-max/ghaction-github-labeler from v3.1.0 to v3.1.1 (#703) @dependabot
* Bump nox from 2020.8.22 to 2020.12.31 in /.github/workflows (#710) @dependabot
* Bump nox-poetry from 0.5.0 to 0.6.0 in /.github/workflows (#693) @dependabot
* Bump nox-poetry from 0.6.0 to 0.7.1 in /.github/workflows (#719) @dependabot
* Bump pip from 20.2.4 to 20.3 in /.github/workflows (#690) @dependabot
* Bump pip from 20.3 to 20.3.1 in /.github/workflows (#692) @dependabot
* Bump pip from 20.3.1 to 21.0 in /.github/workflows (#738) @dependabot
* Bump poetry from 1.1.2 to 1.1.4 in /.github/workflows (#637) @dependabot
* Bump pre-commit from 2.8.2 to 2.9.0 in /.github/workflows (#678) @dependabot
* Bump pre-commit from 2.9.0 to 2.9.2 in /.github/workflows (#687) @dependabot
* Bump pre-commit from 2.9.2 to 2.9.3 in /.github/workflows (#697) @dependabot
* Bump pre-commit from 2.9.3 to 2.10.0 in /.github/workflows (#750) @dependabot
* Bump release-drafter/release-drafter from v5.12.1 to v5.13.0 (#709) @dependabot
* Bump sphinx from 3.3.1 to 3.4.3 in /docs (#716) @dependabot
* Bump virtualenv from 20.1.0 to 20.2.0 in /.github/workflows (#677) @dependabot
* Bump virtualenv from 20.2.0 to 20.2.1 in /.github/workflows (#679) @dependabot
* Bump virtualenv from 20.2.1 to 20.4.0 in /.github/workflows (#734) @dependabot
