### PR TITLE
Default to main branch in release tool

### DIFF
--- a/tools/prepare-github-release.py
+++ b/tools/prepare-github-release.py
@@ -113,7 +113,7 @@ def prepare_release(
 @click.option(
     "--base",
     metavar="BRANCH",
-    default="master",
+    default="main",
     help="default branch of the GitHub repository",
 )
 @click.option(


### PR DESCRIPTION
Now that this repository has switched to the `main` branch, change the defaults in the release automation tools accordingly.