### PR TITLE
Revert "Ignore CVE-2020-28476 affecting all versions of tornado (#763)"

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -100,9 +100,7 @@ def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = session.poetry.export_requirements()
     session.install("safety")
-    # Ignore CVE-2020-28476 affecting all versions of tornado
-    # https://github.com/tornadoweb/tornado/issues/2981
-    session.run("safety", "check", f"--file={requirements}", "--bare", "--ignore=39462")
+    session.run("safety", "check", f"--file={requirements}", "--bare")
 
 
 @session(python=python_versions)


### PR DESCRIPTION
This reverts commit 8688123d9981926d8811c438e4e67bec431adf7f.

The CVE has been revoked.