### PR TITLE
Release 2021.3.14

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
 
 .. code:: console
 
-   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.1.29
+   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.3.14
 
 
 Features

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -63,9 +63,9 @@ The |HPC| has a monthly release cadence while in alpha status.
 Releases happen on the 15th of every month.
 We use `Calendar Versioning`_ with a ``YYYY.MM.DD`` versioning scheme.
 
-The current stable release is `2021.1.29`_.
+The current stable release is `2021.3.14`_.
 
-.. _2021.1.29: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.1.29
+.. _2021.3.14: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.3.14
 
 
 .. _Installation:
@@ -220,12 +220,12 @@ Creating a project
 
 Create a project from this template
 by pointing Cookiecutter to its `GitHub repository <Hypermodern Python Cookiecutter_>`__.
-Use the ``--checkout`` option with the `current stable release <2021.1.29_>`__:
+Use the ``--checkout`` option with the `current stable release <2021.3.14_>`__:
 
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.1.29"
+     --checkout="2021.3.14"
 
 Cookiecutter downloads the template,
 and asks you a series of questions about project variables,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Usage
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.1.29"
+     --checkout="2021.3.14"
 
 
 Features

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Generate a Python project:
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.1.29"
+     --checkout="2021.3.14"
 
 Change to the root directory of your new project,
 and create a Git repository:


### PR DESCRIPTION
## Overview of Changes

This release allows generated projects to choose a license. Supported licenses are MIT, Apache-2.0, and GPL-3.0.

## Changes

This section lists changes affecting generated projects.

### :rocket: Features

* Add license parameter (#701) @paw-lu

### :rotating_light: Testing

* Use session decorator from nox-poetry (#769) @cjolowicz

### :books: Documentation

* Fix reference to master in Codecov link on README (#788) @cjolowicz

## :package: Dependencies

* Bump actions/cache from v2.1.3 to v2.1.4 (#780) @cjolowicz
* Bump codecov/codecov-action from v1.2.1 to v1.2.2 (#815) @cjolowicz
* Bump darglint from 1.5.8 to 1.6.0 (#783) @cjolowicz
* Bump darglint from 1.6.0 to 1.7.0 (#810) @cjolowicz
* Bump flake8-bugbear from 20.11.1 to 21.3.2 (#808) @cjolowicz
* Bump jinja2 from 2.11.2 to 2.11.3 (#801) @cjolowicz
* Bump mypy from 0.800 to 0.812 (#807) @cjolowicz
* Bump nox-poetry from 0.7.1 to 0.8.1 in /.github/workflows (#768) @cjolowicz
* Bump nox-poetry from 0.8.1 to 0.8.2 in /.github/workflows (#819) @cjolowicz
* Bump pip from 21.0 to 21.0.1 in /.github/workflows (#784) @cjolowicz
* Bump poetry from 1.1.4 to 1.1.5 in /.github/workflows (#804) @cjolowicz
* Bump pre-commit from 2.10.0 to 2.10.1 (#778) @cjolowicz
* Bump pre-commit from 2.10.1 to 2.11.1 (#813) @cjolowicz
* Bump pygments from 2.7.4 to 2.8.0 (#775) @cjolowicz
* Bump pygments from 2.8.0 to 2.8.1 (#814) @cjolowicz
* Bump pypa/gh-action-pypi-publish from v1.4.1 to v1.4.2 (#777) @cjolowicz
* Bump pyyaml from 5.3.1 to 5.4.1 (#802) @cjolowicz
* Bump release-drafter/release-drafter from v5.13.0 to v5.14.0 (#776) @cjolowicz
* Bump reorder-python-imports from 2.3.6 to 2.4.0 (#779) @cjolowicz
* Bump sphinx from 3.4.3 to 3.5.1 (#786) @cjolowicz
* Bump sphinx from 3.4.3 to 3.5.1 in /docs (#774) @cjolowicz
* Bump sphinx from 3.5.1 to 3.5.2 (#812) @cjolowicz
* Bump sphinx from 3.5.1 to 3.5.2 in /docs (#803) @cjolowicz
* Bump sphinx-click from 2.5.0 to 2.6.0 (#809) @cjolowicz
* Bump sphinx-click from 2.5.0 to 2.6.0 in /docs (#805) @cjolowicz
* Bump typeguard from 2.10.0 to 2.11.1 (#785) @cjolowicz
* Bump virtualenv from 20.4.0 to 20.4.2 in /.github/workflows (#781) @cjolowicz
* Bump xdoctest from 0.15.3 to 0.15.4 (#782) @cjolowicz
* Update subdependencies (#816) @cjolowicz

## Changes to the Cookiecutter

This section lists changes to the Cookiecutter that don't affect generated projects.

### :construction_worker: Continuous Integration

* Use main branch in GA workflows (#806) @cjolowicz
* Default to main branch in release tool (#789) @cjolowicz
* Fix release automation for Cookiecutter template (#759) @cjolowicz

<!--
* Revert "Ignore CVE-2020-28476 affecting all versions of tornado (#763)" (#797) @cjolowicz
* Ignore CVE-2020-28476 affecting all versions of tornado (#763) @cjolowicz
-->

## :package: Dependencies

* Bump actions/cache from v2.1.3 to v2.1.4 (#765) @dependabot
* Bump nox-poetry from 0.7.1 to 0.8.1 in /.github/workflows (#766) @dependabot
* Bump nox-poetry from 0.8.1 to 0.8.2 in /.github/workflows (#820) @dependabot
* Bump pip from 21.0 to 21.0.1 in /.github/workflows (#760) @dependabot
* Bump poetry from 1.1.4 to 1.1.5 in /.github/workflows (#798) @dependabot
* Bump pre-commit from 2.10.0 to 2.10.1 in /.github/workflows (#767) @dependabot
* Bump pre-commit from 2.10.1 to 2.11.0 in /.github/workflows (#800) @dependabot
* Bump pre-commit from 2.11.0 to 2.11.1 in /.github/workflows (#811) @dependabot
* Bump release-drafter/release-drafter from v5.13.0 to v5.14.0 (#770) @dependabot
* Bump sphinx from 3.4.3 to 3.5.1 in /docs (#772) @dependabot
* Bump sphinx from 3.5.1 to 3.5.2 in /docs (#799) @dependabot
* Bump virtualenv from 20.4.0 to 20.4.2 in /.github/workflows (#764) @dependabot
