### PR TITLE
Switch instance repository to main branch

### DIFF
--- a/.github/workflows/reset-instance.yml
+++ b/.github/workflows/reset-instance.yml
@@ -59,4 +59,4 @@ jobs:
           -C cookiecutter-hypermodern-python-instance
           push
           https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/cjolowicz/cookiecutter-hypermodern-python-instance.git
-          HEAD:master
+          HEAD:main

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ cookiecutter-hypermodern-python
 .. |Tests| image:: https://github.com/cjolowicz/cookiecutter-hypermodern-python/workflows/Tests/badge.svg
    :target: https://github.com/cjolowicz/cookiecutter-hypermodern-python/actions?workflow=Tests
    :alt: Tests
-.. |Codecov| image:: https://codecov.io/gh/cjolowicz/cookiecutter-hypermodern-python-instance/branch/master/graph/badge.svg
+.. |Codecov| image:: https://codecov.io/gh/cjolowicz/cookiecutter-hypermodern-python-instance/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/cjolowicz/cookiecutter-hypermodern-python-instance
    :alt: Codecov
 .. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white


### PR DESCRIPTION
Update the "Reset Instance" workflow and the badges to point to the new default branch of https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance.