### PR TITLE
Include test suite in code coverage

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -59,6 +59,7 @@ source = ["src", "*/site-packages"]
 
 [tool.coverage.run]
 branch = true
+relative_files = true
 source = ["{{cookiecutter.package_name}}", "tests"]
 
 [tool.coverage.report]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -59,7 +59,7 @@ source = ["src", "*/site-packages"]
 
 [tool.coverage.run]
 branch = true
-source = ["{{cookiecutter.package_name}}"]
+source = ["{{cookiecutter.package_name}}", "tests"]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
Closes #792 

Include the test suite in code coverage, via the [coverage.run.source] setting.

[coverage.run.source]: https://coverage.readthedocs.io/en/coverage-5.3/source.html#source

Rationale:

- Tests are code.
- Identify tests that aren’t running.
- Ensure that test helpers are used and tested.

Caveats:

- Coverage may require extra configuration if tests are deliberately excluded.
- Tests may clutter the coverage report; use `--skip-covered` for this.
- The coverage metric generally goes up.

https://nedbatchelder.com/blog/202008/you_should_include_your_tests_in_coverage.html

This PR also enables the [coverage.run.relative_files] setting, to store paths relative to the repository in the coverage data files. By default, coverage data contains absolute paths for the test suite. During CI, coverage data from various runners is combined in an environment where these paths do not exist. This results in errors like the following:

```
No source for code: '/Users/runner/work/cookiecutter-hypermodern-python-instance/cookiecutter-hypermodern-python-instance/tests/__init__.py'.
Aborting report output, consider using -i.
```

[coverage.run.relative_files]: https://coverage.readthedocs.io/en/coverage-5.3/config.html#config-run-relative-files

The [coverage.paths] setting does not help with the test suite: Unlike the code under `src`, the test suite is not installed to `site-packages`, so we'd need to either hardcode paths from individual runners, or use overly generic wildcards. The setting is still needed for `src` though, because even the relative paths include the location of the various Nox environments.

[coverage.paths]: https://coverage.readthedocs.io/en/coverage-5.3/config.html#paths

