### PR TITLE
Print full report in safety session

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -100,7 +100,7 @@ def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = session.poetry.export_requirements()
     session.install("safety")
-    session.run("safety", "check", f"--file={requirements}", "--bare")
+    session.run("safety", "check", "--full-report", f"--file={requirements}")
 
 
 @session(python=python_versions)


### PR DESCRIPTION
Closes #818 

Invoke safety with the `--full-report` option, to provide additional information, such as the Safety DB identifier and the affected version ranges. Previously, the safety session used `--bare` which prints only the names of vulnerable packages.