### PR TITLE
Configure flake8-rst-docstrings for Sphinx

### DIFF
--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -5,3 +5,5 @@ max-line-length = 80
 max-complexity = 10
 docstring-convention = google
 per-file-ignores = tests/*:S101
+rst-roles = class,const,func,meth,mod,ref
+rst-directives = deprecated


### PR DESCRIPTION
Closes #794 

This PR configures [flake8-rst-docstrings] to recognize some common [Sphinx roles] and [directives]:

[flake8-rst-docstrings]: https://github.com/peterjc/flake8-rst-docstrings
[Sphinx roles]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html
[directives]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-deprecated

- class
- const
- func
- meth
- mod
- ref
- deprecated
