### PR TITLE
Release 2021.4.15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
 
 .. code:: console
 
-   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.3.14
+   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.4.15
 
 
 Features

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,4 +30,5 @@ linkcheck_ignore = [
     "https://github.com/pycqa/pep8-naming#",
     "https://github.com/terrencepreilly/darglint#",
     "https://github.com/PyCQA/mccabe#",
+    "https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/",
 ]

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -63,9 +63,9 @@ The |HPC| has a monthly release cadence while in alpha status.
 Releases happen on the 15th of every month.
 We use `Calendar Versioning`_ with a ``YYYY.MM.DD`` versioning scheme.
 
-The current stable release is `2021.3.14`_.
+The current stable release is `2021.4.15`_.
 
-.. _2021.3.14: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.3.14
+.. _2021.4.15: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.4.15
 
 
 .. _Installation:
@@ -220,12 +220,12 @@ Creating a project
 
 Create a project from this template
 by pointing Cookiecutter to its `GitHub repository <Hypermodern Python Cookiecutter_>`__.
-Use the ``--checkout`` option with the `current stable release <2021.3.14_>`__:
+Use the ``--checkout`` option with the `current stable release <2021.4.15_>`__:
 
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.3.14"
+     --checkout="2021.4.15"
 
 Cookiecutter downloads the template,
 and asks you a series of questions about project variables,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Usage
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.3.14"
+     --checkout="2021.4.15"
 
 
 Features

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Generate a Python project:
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.3.14"
+     --checkout="2021.4.15"
 
 Change to the root directory of your new project,
 and create a Git repository:


### PR DESCRIPTION
## Overview of Changes

This release contains various minor improvements to automated checks.

## Changes

This section lists changes affecting generated projects.

## :rotating_light: Testing

* Configure darglint to allow long docstrings without signatures (#871) @cjolowicz
* Configure flake8-rst-docstrings for Sphinx (#876) @cjolowicz
* Print full report in safety session (#872) @cjolowicz
* Simplify mypy.ini using the strict setting (#869) @cjolowicz
* Improve error message when nox-poetry is not installed (#875) @cjolowicz

## :package: Dependencies

* Bump actions/cache from v2.1.4 to v2.1.5 (#853) @cjolowicz
* Bump actions/download-artifact from v2.0.8 to v2.0.9 (#857) @cjolowicz
* Bump actions/setup-python from v2.2.1 to v2.2.2 (#866) @cjolowicz
* Bump actions/upload-artifact from v2.2.2 to v2.2.3 (#858) @cjolowicz
* Bump codecov/codecov-action from v1.2.2 to v1.3.1 (#833) @cjolowicz
* Bump codecov/codecov-action from v1.3.1 to v1.3.2 (#861) @cjolowicz
* Bump darglint from 1.7.0 to 1.8.0 (#862) @cjolowicz
* Bump flake8 from 3.8.4 to 3.9.0 (#829) @cjolowicz
* Bump flake8-bugbear from 21.3.2 to 21.4.3 (#845) @cjolowicz
* Bump flake8-docstrings from 1.5.0 to 1.6.0 (#842) @cjolowicz
* Bump nox-poetry from 0.8.2 to 0.8.4 in /.github/workflows (#827) @cjolowicz
* Bump poetry from 1.1.5 to 1.1.6 in /.github/workflows (#865) @cjolowicz
* Bump pre-commit from 2.11.1 to 2.12.0 (#856) @cjolowicz
* Bump pytest from 6.2.2 to 6.2.3 (#863) @cjolowicz
* Bump release-drafter/release-drafter from v5.14.0 to v5.15.0 (#832) @cjolowicz
* Bump sphinx from 3.5.2 to 3.5.3 (#838) @cjolowicz
* Bump sphinx from 3.5.2 to 3.5.3 in /docs (#840) @cjolowicz
* Bump sphinx from 3.5.3 to 3.5.4 (#854) @cjolowicz
* Bump sphinx from 3.5.3 to 3.5.4 in /docs (#855) @cjolowicz
* Bump sphinx-autobuild from 2020.9.1 to 2021.3.14 (#828) @cjolowicz
* Bump sphinx-click from 2.6.0 to 2.7.1 (#839) @cjolowicz
* Bump sphinx-click from 2.6.0 to 2.7.1 in /docs (#841) @cjolowicz
* Bump sphinx-rtd-theme from 0.5.1 to 0.5.2 (#859) @cjolowicz
* Bump sphinx-rtd-theme from 0.5.1 to 0.5.2 in /docs (#860) @cjolowicz
* Bump typeguard from 2.11.1 to 2.12.0 (#844) @cjolowicz
* Bump urllib3 from 1.26.3 to 1.26.4 (#843) @cjolowicz
* Bump virtualenv from 20.4.2 to 20.4.3 in /.github/workflows (#834) @cjolowicz
* Upgrade subdependencies (#867) @cjolowicz

## Changes to the Cookiecutter

This section lists changes to the Cookiecutter that don't affect generated projects.

## :rotating_light: Testing

* Check for dead links in documentation (#699) @oncleben31

## :construction_worker: Continuous Integration

* Switch instance repository to main branch (#868) @cjolowicz

## :books: Documentation

* Include Labeler workflow in "Files and Directories" table in User Guide (#874) @cjolowicz
* Update User Guide to reflect recent changes in mypy.ini (#873) @cjolowicz

## :package: Dependencies

* Bump actions/cache from v2.1.4 to v2.1.5 (#851) @dependabot
* Bump actions/setup-python from v2.2.1 to v2.2.2 (#852) @dependabot
* Bump nox-poetry from 0.8.2 to 0.8.4 in /.github/workflows (#826) @dependabot
* Bump poetry from 1.1.5 to 1.1.6 in /.github/workflows (#864) @dependabot
* Bump pre-commit from 2.11.1 to 2.12.0 in /.github/workflows (#849) @dependabot
* Bump release-drafter/release-drafter from v5.14.0 to v5.15.0 (#830) @dependabot
* Bump sphinx from 3.5.2 to 3.5.3 in /docs (#837) @dependabot
* Bump sphinx from 3.5.3 to 3.5.4 in /docs (#850) @dependabot
* Bump sphinx-autobuild from 2020.9.1 to 2021.3.14 in /docs (#824) @dependabot
* Bump virtualenv from 20.4.2 to 20.4.3 in /.github/workflows (#831) @dependabot
