### PR TITLE
Simplify Nox session for code coverage

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -21,6 +21,7 @@ except ImportError:
 
 package = "{{cookiecutter.package_name}}"
 python_versions = ["3.9", "3.8", "3.7", "3.6"]
+nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     "pre-commit",
     "safety",

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -133,20 +133,17 @@ def tests(session: Session) -> None:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:
         if session.interactive:
-            session.notify("coverage")
+            session.notify("coverage", posargs=[])
 
 
 @session
 def coverage(session: Session) -> None:
     """Produce the coverage report."""
-    # Do not use session.posargs unless this is the only session.
-    nsessions = len(session._runner.manifest)
-    has_args = session.posargs and nsessions == 1
-    args = session.posargs if has_args else ["report"]
+    args = session.posargs or ["report"]
 
     session.install("coverage[toml]")
 
-    if not has_args and any(Path().glob(".coverage.*")):
+    if not session.posargs and any(Path().glob(".coverage.*")):
         session.run("coverage", "combine")
 
     session.run("coverage", *args)


### PR DESCRIPTION
This PR simplifies the handling of `posargs` in the Nox session for Coverage.py.

Pass empty `posargs` when scheduling the coverage sesseion via `session.notify`. This avoids invoking `coverage` with options intended for pytest. Previously, our solution relied on inspecting a private attribute of `nox.Session`.

The `posargs` parameter for `session.notify` was introduced in Nox 2021.6.6.

Use the `nox.needs_version` attribute to declare the dependency on Nox >= 2021.6.6.

Note: This requires nox-poetry 0.8.6 to avoid an error from mypy.