### PR TITLE
Release 2021.6.15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
 
 .. code:: console
 
-   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.4.15
+   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.6.15
 
 
 Features

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -63,9 +63,9 @@ The |HPC| has a monthly release cadence while in alpha status.
 Releases happen on the 15th of every month.
 We use `Calendar Versioning`_ with a ``YYYY.MM.DD`` versioning scheme.
 
-The current stable release is `2021.4.15`_.
+The current stable release is `2021.6.15`_.
 
-.. _2021.4.15: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.4.15
+.. _2021.6.15: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.6.15
 
 
 .. _Installation:
@@ -220,12 +220,12 @@ Creating a project
 
 Create a project from this template
 by pointing Cookiecutter to its `GitHub repository <Hypermodern Python Cookiecutter_>`__.
-Use the ``--checkout`` option with the `current stable release <2021.4.15_>`__:
+Use the ``--checkout`` option with the `current stable release <2021.6.15_>`__:
 
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.4.15"
+     --checkout="2021.6.15"
 
 Cookiecutter downloads the template,
 and asks you a series of questions about project variables,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Usage
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.4.15"
+     --checkout="2021.6.15"
 
 
 Features

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Generate a Python project:
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.4.15"
+     --checkout="2021.6.15"
 
 Change to the root directory of your new project,
 and create a Git repository:


### PR DESCRIPTION
## Overview of Changes

- Generated projects now have one configuration file less, as the mypy configuration was moved to the `pyproject.toml` file.
- Documentation is now built using Python 3.9, both on ReadTheDocs and locally.
- The `noxfile.py` now requires a recent version of Nox.

Read on for the complete list of changes.

## Changes

This section lists changes affecting generated projects.

### :rotating_light: Testing

* Move `mypy` configuration into `pyproject.toml` (#935) @yeskunall
* Update pre-commit hook for Prettier to new repository (#916) @staticdev
* Simplify Nox session for code coverage (#943) @cjolowicz
* Add per-machine coverage data files to `.gitignore` file (#886) @cjolowicz

### :books: Documentation

* Use Python 3.9 when building on ReadTheDocs (#946) @cjolowicz

### :package: Dependencies

* Require click 8.x (#947) @staticdev
* Bump actions/cache from 2.1.5 to 2.1.6 (#923) @cjolowicz
* Bump actions/checkout from 2.3.3 to 2.3.4 (#931) @cjolowicz
* Bump click from 7.1.2 to 8.0.1 (#944) @cjolowicz
* Bump click from 7.1.2 to 8.0.1 in poetry.lock (#945) @cjolowicz
* Bump codecov/codecov-action from 1.5.0 to 1.5.2 (#920) @cjolowicz
* Bump codecov/codecov-action from v1.3.2 to v1.4.1 (#892) @cjolowicz
* Bump codecov/codecov-action from v1.4.1 to v1.5.0 (#900) @cjolowicz
* Bump docs and docs-build session python to 3.9 (#646) @staticdev
* Bump flake8 from 3.9.0 to 3.9.1 (#881) @cjolowicz
* Bump flake8 from 3.9.1 to 3.9.2 (#932) @cjolowicz
* Bump flake8-rst-docstrings from 0.0.14 to 0.1.1 (#880) @cjolowicz
* Bump flake8-rst-docstrings from 0.0.14 to 0.2.1 (#889) @cjolowicz
* Bump flake8-rst-docstrings from 0.2.1 to 0.2.2 (#896) @cjolowicz
* Bump flake8-rst-docstrings from 0.2.2 to 0.2.3 (#898) @cjolowicz
* Bump mypy from 0.812 to 0.902 (#937) @cjolowicz
* Bump nox from 2020.12.31 to 2021.6.12 in /.github/workflows (#936) @cjolowicz
* Bump nox-poetry from 0.8.5 to 0.8.6 in /.github/workflows (#940) @cjolowicz
* Bump pip from 21.0.1 to 21.1 in /.github/workflows (#890) @cjolowicz
* Bump pip from 21.1 to 21.1.1 in /.github/workflows (#897) @cjolowicz
* Bump pip from 21.1.1 to 21.1.2 in /.github/workflows (#926) @cjolowicz
* Bump pre-commit from 2.12.0 to 2.12.1 (#893) @cjolowicz
* Bump pre-commit from 2.12.1 to 2.13.0 (#925) @cjolowicz
* Bump pre-commit-hooks from 3.4.0 to 4.0.1 (#928) @cjolowicz
* Bump pygments from 2.8.1 to 2.9.0 (#899) @cjolowicz
* Bump pytest from 6.2.3 to 6.2.4 (#902) @cjolowicz
* Bump reorder-python-imports from 2.4.0 to 2.5.0 (#888) @cjolowicz
* Bump sphinx from 3.5.4 to 4.0.2 (#941) @cjolowicz
* Bump sphinx from 3.5.4 to 4.0.2 in /docs (#927) @cjolowicz
* Bump sphinx-click from 2.7.1 to 3.0.1 (#938) @cjolowicz
* Bump sphinx-click from 2.7.1 to 3.0.1 in /docs (#939) @cjolowicz
* Bump typeguard from 2.12.0 to 2.12.1 (#921) @cjolowicz
* Bump virtualenv from 20.4.3 to 20.4.4 in /.github/workflows (#891) @cjolowicz
* Bump virtualenv from 20.4.4 to 20.4.6 in /.github/workflows (#904) @cjolowicz
* Bump virtualenv from 20.4.4 to 20.4.7 in /.github/workflows (#924) @cjolowicz

## Changes to the Cookiecutter

This section lists changes to the Cookiecutter that don't affect generated projects.

### :construction_worker: Continuous Integration

* Add label `skip-changelog` for excluding PRs from release notes (#675) @cjolowicz

### :books: Documentation

* Update CONTRIBUTORS.rst (#948) @cjolowicz
* Update link on poetry version constraints (#919) @staticdev
* Fix broken link to pip docs in User Guide (#887) @cjolowicz
* Remove obsolete note on `mypy --ignore-missing-imports` from User Guide (#878) @cjolowicz

### :package: Dependencies

* Bump actions/cache from 2.1.5 to 2.1.6 (#913) @dependabot
* Bump cookiecutter from 1.7.2 to 1.7.3 in /.github/workflows (#907) @dependabot
* Bump nox from 2020.12.31 to 2021.6.12 in /.github/workflows (#933) @dependabot
* Bump nox-poetry from 0.8.4 to 0.8.5 in /.github/workflows (#894) @dependabot
* Bump nox-poetry from 0.8.5 to 0.8.6 in /.github/workflows (#934) @dependabot
* Bump pip from 21.0.1 to 21.1 in /.github/workflows (#884) @dependabot
* Bump pip from 21.1 to 21.1.1 in /.github/workflows (#895) @dependabot
* Bump pip from 21.1.1 to 21.1.2 in /.github/workflows (#910) @dependabot
* Bump pre-commit from 2.12.0 to 2.12.1 in /.github/workflows (#882) @dependabot
* Bump pre-commit from 2.12.1 to 2.13.0 in /.github/workflows (#911) @dependabot
* Bump sphinx from 3.5.4 to 4.0.2 in /docs (#909) @dependabot
* Bump virtualenv from 20.4.3 to 20.4.4 in /.github/workflows (#883) @dependabot
* Bump virtualenv from 20.4.4 to 20.4.6 in /.github/workflows (#903) @dependabot
* Bump virtualenv from 20.4.6 to 20.4.7 in /.github/workflows (#912) @dependabot
