### PR TITLE
Remove types-click from Nox session for mypy

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -119,7 +119,7 @@ def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "tests", "docs/conf.py"]
     session.install(".")
-    session.install("mypy", "pytest", "types-click")
+    session.install("mypy", "pytest")
     session.run("mypy", *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__main__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__main__.py
@@ -2,12 +2,8 @@
 import click
 
 
-# @click.version_option results in "untyped decorator" error
-# https://github.com/python/typeshed/issues/5642
-
-
 @click.command()
-@click.version_option()  # type: ignore[misc]
+@click.version_option()
 def main() -> None:
     """{{cookiecutter.friendly_name}}."""
 


### PR DESCRIPTION
click >= 8.0 ships with py.typed, so types-click is not required.

Installing types-click with click >= 8.0 leads to a mypy error, see python/typeshed#5642