### PR TITLE
Release 2021.7.15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
 
 .. code:: console
 
-   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.6.16
+   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.7.15
 
 
 Features

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -63,9 +63,9 @@ The |HPC| has a monthly release cadence while in alpha status.
 Releases happen on the 15th of every month.
 We use `Calendar Versioning`_ with a ``YYYY.MM.DD`` versioning scheme.
 
-The current stable release is `2021.6.16`_.
+The current stable release is `2021.7.15`_.
 
-.. _2021.6.16: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.6.16
+.. _2021.7.15: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.7.15
 
 
 .. _Installation:
@@ -220,12 +220,12 @@ Creating a project
 
 Create a project from this template
 by pointing Cookiecutter to its `GitHub repository <Hypermodern Python Cookiecutter_>`__.
-Use the ``--checkout`` option with the `current stable release <2021.6.16_>`__:
+Use the ``--checkout`` option with the `current stable release <2021.7.15_>`__:
 
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.6.16"
+     --checkout="2021.7.15"
 
 Cookiecutter downloads the template,
 and asks you a series of questions about project variables,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Usage
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.6.16"
+     --checkout="2021.7.15"
 
 
 Features

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Generate a Python project:
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.6.16"
+     --checkout="2021.7.15"
 
 Change to the root directory of your new project,
 and create a Git repository:


### PR DESCRIPTION
## Overview of Changes

This release allows marking the development status (e.g. alpha, beta, stable) when generating a project. The development status is included in the package metadata and indicated by a badge in the README and documentation.

## Changes

This section lists changes affecting generated projects.

### :rocket: Features

* Add Trove classifier for Development Status (#981) @cjolowicz

### :package: Dependencies

* Bump actions/download-artifact from 2.0.9 to 2.0.10 (#973) @cjolowicz
* Bump actions/upload-artifact from 2.2.3 to 2.2.4 (#974) @cjolowicz
* Bump mypy from 0.902 to 0.910 (#972) @cjolowicz
* Bump pep8-naming from 0.11.1 to 0.12.0 (#968) @cjolowicz
* Bump pip from 21.1.2 to 21.1.3 in /.github/workflows (#970) @cjolowicz
* Bump poetry from 1.1.6 to 1.1.7 in /.github/workflows (#971) @cjolowicz
* Bump sphinx from 4.0.2 to 4.1.1 (#975) @cjolowicz
* Bump sphinx from 4.0.2 to 4.1.1 in /docs (#976) @cjolowicz
* Bump virtualenv from 20.4.7 to 20.5.0 in /.github/workflows (#965) @cjolowicz
* Bump virtualenv from 20.5.0 to 20.6.0 in /.github/workflows (#977) @cjolowicz
* Bump xdoctest from 0.15.4 to 0.15.5 (#969) @cjolowicz

## Changes to the Cookiecutter

This section lists changes to the Cookiecutter that don't affect generated projects.

### :books: Documentation

* Update Poetry installation instructions to use `install-poetry.py` (#960) @staticdev

### :package: Dependencies

* Bump pip from 21.1.2 to 21.1.3 in /.github/workflows (#954) @dependabot
* Bump poetry from 1.1.6 to 1.1.7 in /.github/workflows (#955) @dependabot
* Bump sphinx from 4.0.2 to 4.0.3 in /docs (#958) @dependabot
* Bump sphinx from 4.0.3 to 4.1.0 in /docs (#961) @dependabot
* Bump sphinx from 4.1.0 to 4.1.1 in /docs (#979) @dependabot
* Bump virtualenv from 20.4.7 to 20.5.0 in /.github/workflows (#964) @dependabot
* Bump virtualenv from 20.5.0 to 20.6.0 in /.github/workflows (#980) @dependabot
