### PR TITLE
Chain exception correctly

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -16,7 +16,7 @@ except ImportError:
     Please install it using the following command:
 
     {sys.executable} -m pip install nox-poetry"""
-    raise SystemExit(dedent(message))
+    raise SystemExit(dedent(message)) from None
 
 
 package = "{{cookiecutter.package_name}}"


### PR DESCRIPTION
According to https://docs.python.org/3/tutorial/errors.html#exception-chaining
And to avoid the error B904 when you will bump flake8-bugbear to a version > 21.9.1, we have to use `raise ... from err` or `raise ... from None`.

As the SysExit() Exception is used I think there is no need to display the exceptions chain. So I propose to use `from None`.