### PR TITLE
Release 2021.11.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
 
 .. code:: console
 
-   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.7.15
+   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.11.8
 
 
 Features

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -63,9 +63,9 @@ The |HPC| has a monthly release cadence while in alpha status.
 Releases happen on the 15th of every month.
 We use `Calendar Versioning`_ with a ``YYYY.MM.DD`` versioning scheme.
 
-The current stable release is `2021.7.15`_.
+The current stable release is `2021.11.8`_.
 
-.. _2021.7.15: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.7.15
+.. _2021.11.8: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.11.8
 
 
 .. _Installation:
@@ -220,12 +220,12 @@ Creating a project
 
 Create a project from this template
 by pointing Cookiecutter to its `GitHub repository <Hypermodern Python Cookiecutter_>`__.
-Use the ``--checkout`` option with the `current stable release <2021.7.15_>`__:
+Use the ``--checkout`` option with the `current stable release <2021.11.8_>`__:
 
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.7.15"
+     --checkout="2021.11.8"
 
 Cookiecutter downloads the template,
 and asks you a series of questions about project variables,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Usage
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.7.15"
+     --checkout="2021.11.8"
 
 
 Features

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Generate a Python project:
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.7.15"
+     --checkout="2021.11.8"
 
 Change to the root directory of your new project,
 and create a Git repository:


### PR DESCRIPTION
## Overview of Changes

- This release adds support for Python 3.10, while dropping support for Python 3.6
(EOL in December 2021).
- Poetry and Nox are now installed on GitHub Actions using pipx, in isolated environments.
- mypy is now configured to warn about unreachable code.

Read on for the full list of changes.

## Changes

This section lists changes affecting generated projects.

### :boom: Breaking Changes

* Drop support for Python 3.6 (#1054) @cjolowicz

### :rocket: Features

* Support Python 3.10 (#1052) @cjolowicz

### :construction_worker: Continuous Integration

* Install Poetry and Nox using pipx in Tests workflow (#1051) @cjolowicz

### :rotating_light: Testing

* [nox] Chain exception correctly (#1015) @oncleben31
* [mypy] Warn about unreachable code (#1025) @cjolowicz

### 📚 Documentation

* Fix typo in CONTRIBUTING.rst (#1010) @benjaminrose

### :package: Dependencies

* Bump actions/checkout from 2.3.4 to 2.4.0 (#1026) @cjolowicz
* Bump babel from 2.9.0 to 2.9.1 (#1023) @cjolowicz
* Bump black from 20.8b1 to 21.10b0 (#1055) @cjolowicz
* Bump click from 8.0.1 to 8.0.3 (#1042) @cjolowicz
* Bump codecov/codecov-action from 1.5.2 to 2.0.2 (#994) @cjolowicz
* Bump codecov/codecov-action from 2.0.2 to 2.1.0 (#1034) @cjolowicz
* Bump coverage from 5.5 to 6.1.1 (#1041) @cjolowicz
* Bump darglint from 1.8.0 to 1.8.1 (#1048) @cjolowicz
* Bump flake8 from 3.9.2 to 4.0.1 (#1044) @cjolowicz
* Bump flake8-bugbear from 21.4.3 to 21.9.2 (#1043) @cjolowicz
* Bump nox from 2021.6.12 to 2021.10.1 in /.github/workflows (#1031) @cjolowicz
* Bump pep8-naming from 0.12.0 to 0.12.1 (#1037) @cjolowicz
* Bump pip from 21.1.3 to 21.2.1 in /.github/workflows (#993) @cjolowicz
* Bump pip from 21.2.1 to 21.3.1 in /.github/workflows (#1028) @cjolowicz
* Bump poetry from 1.1.7 to 1.1.11 in /.github/workflows (#1030) @cjolowicz
* Bump pre-commit from 2.13.0 to 2.15.0 (#1035) @cjolowicz
* Bump prettier from 2.3.0 to 2.4.1 (#1056) @cjolowicz
* Bump pygments from 2.9.0 to 2.10.0 (#1036) @cjolowicz
* Bump pytest from 6.2.4 to 6.2.5 (#1038) @cjolowicz
* Bump reorder-python-imports from 2.5.0 to 2.6.0 (#986) @cjolowicz
* Bump sphinx from 4.1.1 to 4.1.2 (#992) @cjolowicz
* Bump sphinx from 4.1.1 to 4.1.2 in /docs (#988) @cjolowicz
* Bump sphinx from 4.1.2 to 4.2.0 (#1040) @cjolowicz
* Bump sphinx from 4.1.2 to 4.2.0 in /docs (#1032) @cjolowicz
* Bump sphinx-click from 3.0.1 to 3.0.2 (#1046) @cjolowicz
* Bump sphinx-click from 3.0.1 to 3.0.2 in /docs (#1047) @cjolowicz
* Bump sphinx-rtd-theme from 0.5.2 to 1.0.0 (#1049) @cjolowicz
* Bump sphinx-rtd-theme from 0.5.2 to 1.0.0 in /docs (#1033) @cjolowicz
* Bump typeguard from 2.12.1 to 2.13.0 (#1039) @cjolowicz
* Bump urllib3 from 1.26.4 to 1.26.5 (#1024) @cjolowicz
* Bump virtualenv from 20.6.0 to 20.10.0 in /.github/workflows (#1027) @cjolowicz
* Bump xdoctest from 0.15.5 to 0.15.10 (#1029) @cjolowicz

## Changes to the Cookiecutter

This section lists changes to the Cookiecutter that don't affect generated projects.

### 📚 Documentation

* Drop statement about release cadence from User Guide (#1057) @cjolowicz

### :construction_worker: Continuous Integration

* GitHub Actions: Add Python 3.10 to the testing (#1021) @cclauss

### :package: Dependencies

* Bump actions/checkout from 2.3.4 to 2.3.5 (#1017) @dependabot
* Bump actions/checkout from 2.3.5 to 2.4.0 (#1022) @dependabot
* Bump nox from 2021.6.12 to 2021.10.1 in /.github/workflows (#1013) @dependabot
* Bump pip from 21.1.3 to 21.2.1 in /.github/workflows (#984) @dependabot
* Bump pip from 21.2.1 to 21.2.3 in /.github/workflows (#998) @dependabot
* Bump pip from 21.2.3 to 21.2.4 in /.github/workflows (#1001) @dependabot
* Bump pip from 21.2.4 to 21.3 in /.github/workflows (#1016) @dependabot
* Bump pip from 21.3 to 21.3.1 in /.github/workflows (#1019) @dependabot
* Bump poetry from 1.1.10 to 1.1.11 in /.github/workflows (#1014) @dependabot
* Bump poetry from 1.1.7 to 1.1.8 in /.github/workflows (#1002) @dependabot
* Bump poetry from 1.1.8 to 1.1.10 in /.github/workflows (#1009) @dependabot
* Bump pre-commit from 2.13.0 to 2.14.0 in /.github/workflows (#997) @dependabot
* Bump pre-commit from 2.14.0 to 2.15.0 in /.github/workflows (#1005) @dependabot
* Bump sphinx from 4.1.1 to 4.1.2 in /docs (#991) @dependabot
* Bump sphinx from 4.1.2 to 4.2.0 in /docs (#1006) @dependabot
* Bump virtualenv from 20.6.0 to 20.7.2 in /.github/workflows (#1000) @dependabot
* Bump virtualenv from 20.7.2 to 20.8.0 in /.github/workflows (#1007) @dependabot
* Bump virtualenv from 20.8.0 to 20.8.1 in /.github/workflows (#1012) @dependabot
* Bump virtualenv from 20.8.1 to 20.9.0 in /.github/workflows (#1018) @dependabot
* Bump virtualenv from 20.9.0 to 20.10.0 in /.github/workflows (#1020) @dependabot
