### PR TITLE
👷 [github] Use pip to install cutty in Reset Instance workflows

### DIFF
--- a/.github/workflows/update-instance.yml
+++ b/.github/workflows/update-instance.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install cutty
         working-directory: ${{ env.TEMPLATE }}
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt cutty
+          pip install --constraint=.github/workflows/constraints.txt cutty
           cutty --version
       - name: Import commit into ${{ env.PROJECT }}
         run: |


### PR DESCRIPTION
This avoids the following error on GA, which I have not been able to reproduce locally:

```
Run pipx install --pip-args=--constraint=.github/workflows/constraints.txt cutty || cat /opt/pipx/logs/cmd_*_pip_errors.log

Fatal error from pip prevented installation. Full pip output in file:

    /opt/pipx/logs/cmd_2021-11-09_13.43.30_pip_errors.log

creating virtual environment...

Some possibly relevant errors from pip install:

installing cutty...

    ERROR: Cannot install cutty because these package versions have conflicting dependencies.

    ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies

Error installing cutty.

PIP STDOUT
----------

The conflict is caused by:
    The user requested cutty
    The user requested (constraint) cutty==0.16.0

To fix this you could try to:

1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

PIP STDERR
----------
ERROR: Cannot install cutty because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
Error: Process completed with exit code 127.
```