### PR TITLE
Release 2021.11.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
 
 .. code:: console
 
-   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.11.8
+   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.11.10
 
 
 Features

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -61,9 +61,9 @@ Version policy
 
 The |HPC| uses `Calendar Versioning`_ with a ``YYYY.MM.DD`` versioning scheme.
 
-The current stable release is `2021.11.8`_.
+The current stable release is `2021.11.10`_.
 
-.. _2021.11.8: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.11.8
+.. _2021.11.10: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.11.10
 
 
 .. _Installation:
@@ -218,12 +218,12 @@ Creating a project
 
 Create a project from this template
 by pointing Cookiecutter to its `GitHub repository <Hypermodern Python Cookiecutter_>`__.
-Use the ``--checkout`` option with the `current stable release <2021.11.8_>`__:
+Use the ``--checkout`` option with the `current stable release <2021.11.10_>`__:
 
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.11.8"
+     --checkout="2021.11.10"
 
 Cookiecutter downloads the template,
 and asks you a series of questions about project variables,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Usage
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.11.8"
+     --checkout="2021.11.10"
 
 
 Features

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Generate a Python project:
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.11.8"
+     --checkout="2021.11.10"
 
 Change to the root directory of your new project,
 and create a Git repository:


### PR DESCRIPTION
## Overview of Changes

This release upgrades the CI checks on Windows and macOS to Python 3.10.

## Changes

* Release 2021.11.10 (cjolowicz/cookiecutter-hypermodern-python-instance#665) @cjolowicz

### :construction_worker: Continuous Integration

* 👷 [github] Use Python 3.10 on Windows and macOS in Tests workflow (cjolowicz/cookiecutter-hypermodern-python-instance#664) @cjolowicz

### :package: Dependencies

* ⬆ [poetry] Update dependencies (cjolowicz/cookiecutter-hypermodern-python-instance#663) @cjolowicz

## Changes to the template infrastructure

### :construction_worker: Continuous Integration

* 👷 [github] Do not update instance with commits imported from it (#1061) @cjolowicz
* 👷 [github] Use pip to install cutty in Reset Instance workflows (#1060) @cjolowicz
* 👷 [github] Use cutty to update the Cookiecutter instance (#1059) @cjolowicz
