### PR TITLE
Release 2021.11.26

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
 
 .. code:: console
 
-   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.11.10
+   $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2021.11.26
 
 
 Features

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -57,9 +57,9 @@ Version policy
 
 The |HPC| uses `Calendar Versioning`_ with a ``YYYY.MM.DD`` versioning scheme.
 
-The current stable release is `2021.11.10`_.
+The current stable release is `2021.11.26`_.
 
-.. _2021.11.10: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.11.10
+.. _2021.11.26: https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/2021.11.26
 
 
 .. _Installation:
@@ -222,12 +222,12 @@ Creating a project
 
 Create a project from this template
 by pointing Cookiecutter to its `GitHub repository <Hypermodern Python Cookiecutter_>`__.
-Use the ``--checkout`` option with the `current stable release <2021.11.10_>`__:
+Use the ``--checkout`` option with the `current stable release <2021.11.26_>`__:
 
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.11.10"
+     --checkout="2021.11.26"
 
 Cookiecutter downloads the template,
 and asks you a series of questions about project variables,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Usage
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.11.10"
+     --checkout="2021.11.26"
 
 
 Features

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Generate a Python project:
 .. code:: console
 
    $ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-     --checkout="2021.11.10"
+     --checkout="2021.11.26"
 
 Change to the root directory of your new project,
 and create a Git repository:


### PR DESCRIPTION
## Overview of Changes

Here are the major changes brought by this release:

- Add a pre-commit hook for [pyupgrade], a tool for upgrading your source code to newer versions of the Python language and standard library.

- Use the [furo] Sphinx theme for documentation. Furo is a clean customizable theme for technical documentation, with a focus on being responsive and easy to navigate and search.

- Include the test suite itself when measuring code coverage: tests are code. Read more about the reasons behind this on [Ned Batchelder's blog][coverage-blog].

- Enable color output on GitHub Actions for pytest, pre-commit, Sphinx, and xdoctest. Tools on GitHub Actions default to monochrome output, and every tool has its own convention for overriding this (if any). This was a fun ride.

[furo]: https://pradyunsg.me/furo/
[pyupgrade]: https://github.com/asottile/pyupgrade
[coverage-blog]: https://nedbatchelder.com/blog/202008/you_should_include_your_tests_in_coverage.html

Read on for the full list of changes.

## Changes

This section lists changes that affect generated projects.

<!-- * Release 2021.11.26 (#708) @cjolowicz -->

### :rotating_light: Testing

* Include test suite in code coverage ([#545](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/545)) @cjolowicz

### :construction_worker: Continuous Integration

* Add pre-commit hook for pyupgrade ([#674](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/674)) @cjolowicz
* Enable colors from pre-commit, pytest, Sphinx, and xdoctest ([#700](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/700)) @cjolowicz
* Use Python 3.10 on Read the Docs ([#698](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/698)) @cjolowicz
* Pin pip in virtual environments ([#707](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/707)) @cjolowicz
* Update test GA workflow for more consistent style ([#697](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/697)) @staticdev
* Shorten `python-version` to `python` in Tests workflow matrix ([#699](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/699)) @cjolowicz

### :books: Documentation

* Use furo Sphinx theme for documentation ([#676](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/676)) @cjolowicz

### :package: Dependencies

* Avoid semver constraints for dependencies using CalVer ([#675](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/675)) @cjolowicz

<details>
<summary>Dependabot PRs</summary>

* Bump actions/cache from 2.1.6 to 2.1.7 ([#702](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/702)) @dependabot
* Bump actions/setup-python from 2.2.2 to 2.3.0 ([#691](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/691)) @dependabot
* Bump bandit from 1.7.0 to 1.7.1 ([#677](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/677)) @dependabot
* Bump black from 21.10b0 to 21.11b0 ([#690](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/690)) @dependabot
* Bump black from 21.11b0 to 21.11b1 ([#696](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/696)) @dependabot
* Bump charset-normalizer from 2.0.7 to 2.0.8 ([#706](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/706)) @dependabot
* Bump coverage from 6.1.1 to 6.1.2 ([#673](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/673)) @dependabot
* Bump filelock from 3.3.2 to 3.4.0 ([#689](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/689)) @dependabot
* Bump furo from 2021.11.12 to 2021.11.16 ([#688](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/688)) @dependabot
* Bump furo from 2021.11.12 to 2021.11.16 in /docs ([#684](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/684)) @dependabot
* Bump furo from 2021.11.16 to 2021.11.23 ([#705](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/705)) @dependabot
* Bump furo from 2021.11.16 to 2021.11.23 in /docs ([#703](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/703)) @dependabot
* Bump identify from 2.3.5 to 2.3.6 ([#686](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/686)) @dependabot
* Bump identify from 2.3.6 to 2.3.7 ([#694](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/694)) @dependabot
* Bump identify from 2.3.7 to 2.4.0 ([#701](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/701)) @dependabot
* Bump jinja2 from 3.0.2 to 3.0.3 ([#668](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/668)) @dependabot
* Bump nox-poetry from 0.8.6 to 0.9.0 in /.github/workflows ([#692](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/692)) @dependabot
* Bump packaging from 21.0 to 21.3 ([#693](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/693)) @dependabot
* Bump pbr from 5.7.0 to 5.8.0 ([#695](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/695)) @dependabot
* Bump pyparsing from 2.4.7 to 3.0.6 ([#678](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/678)) @dependabot
* Bump pyupgrade from 2.29.0 to 2.29.1 ([#685](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/685)) @dependabot
* Bump regex from 2021.11.2 to 2021.11.10 ([#669](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/669)) @dependabot
* Bump snowballstemmer from 2.1.0 to 2.2.0 ([#687](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/687)) @dependabot
* Bump sphinx from 4.2.0 to 4.3.0 ([#672](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/672)) @dependabot
* Bump sphinx from 4.2.0 to 4.3.0 in /docs ([#671](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/671)) @dependabot
* Bump typeguard from 2.13.0 to 2.13.2 ([#704](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/704)) @dependabot
* Bump typing-extensions from 3.10.0.2 to 4.0.0 ([#682](https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance/pull/682)) @dependabot
</details>

## Changes to the template infrastructure

This section lists changes to the infrastructure of the Cookiecutter template. These changes don't affect generated projects.

### :construction_worker: Continuous Integration

* Ignore our RTD page when checking links in documentation (#1081) @cjolowicz

### :books: Documentation

* Use furo Sphinx theme for Cookiecutter documentation (#612) @cjolowicz
* Document pre-commit hook for pyupgrade (#1065) @cjolowicz
* Add furo Sphinx theme to the Cookiecutter documentation (#1066) @cjolowicz
* Add furo Sphinx theme to the Cookiecutter documentation (#1067) @cjolowicz
* Document code coverage for the test suite (#1075) @cjolowicz
* Add section explaining how to upgrade Nox and Poetry (#1076) @cjolowicz

### :package: Dependencies

<details>
<summary>Dependabot PRs</summary>

* Bump actions/cache from 2.1.6 to 2.1.7 (#1078) @dependabot
* Bump actions/setup-python from 2.2.2 to 2.3.0 (#1071) @dependabot
* Bump cutty from 0.16.0 to 0.17.0 in /.github/workflows (#1064) @dependabot
* Bump furo from 2021.11.12 to 2021.11.12.1 in /docs (#1068) @dependabot
* Bump furo from 2021.11.12.1 to 2021.11.16 in /docs (#1070) @dependabot
* Bump furo from 2021.11.16 to 2021.11.23 in /docs (#1079) @dependabot
* Bump nox-poetry from 0.8.6 to 0.9.0 in /.github/workflows (#1072) @dependabot
* Bump sphinx from 4.2.0 to 4.3.0 in /docs (#1063) @dependabot
</details>
