### PR TITLE
Tell isort to use the black profile

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -72,6 +72,9 @@ show_column_numbers = true
 show_error_codes = true
 show_error_context = true
 
+[tool.isort]
+profile = "black"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
vscode uses isort by default to organize imports on save. This will tell vscode to play nicely with the other formatting decisions in hypermodern.