### PR TITLE
Use author template variable in docs' copyright

### DIFF
--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -1,7 +1,7 @@
 """Sphinx configuration."""
 project = "{{cookiecutter.friendly_name}}"
 author = "{{cookiecutter.author}}"
-copyright = "{{cookiecutter.copyright_year}}, {author}"
+copyright = "{{cookiecutter.copyright_year}}, {{cookiecutter.author}}"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",


### PR DESCRIPTION
Closes #1109.
Fixes the docs' copyright notice by using the author template variable.