### PR TITLE
Fix Windows support by handling `sh` shebangs from pre-commit

### DIFF
--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -75,6 +75,11 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             VIRTUAL_ENV={shlex.quote(virtualenv)}
             PATH={shlex.quote(session.bin)}"{os.pathsep}$PATH"
             """,
+        # pre-commit >= 2.17.0 on Windows forces sh shebang
+        "sh": f"""\
+            VIRTUAL_ENV={shlex.quote(virtualenv)}
+            PATH={shlex.quote(session.bin)}"{os.pathsep}$PATH"
+            """,
     }
 
     hookdir = Path(".git") / "hooks"

--- a/{{cookiecutter.project_name}}/noxfile.py
+++ b/{{cookiecutter.project_name}}/noxfile.py
@@ -76,7 +76,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
             PATH={shlex.quote(session.bin)}"{os.pathsep}$PATH"
             """,
         # pre-commit >= 2.17.0 on Windows forces sh shebang
-        "sh": f"""\
+        "/bin/sh": f"""\
             VIRTUAL_ENV={shlex.quote(virtualenv)}
             PATH={shlex.quote(session.bin)}"{os.pathsep}$PATH"
             """,


### PR DESCRIPTION
As of 2.17, [pre-commit prepends a `#!/bin/sh` to its hooks under Windows](https://github.com/pre-commit/pre-commit/pull/2187/files). This breaks `noxfile.py` since `activate_virtualenv_in_precommit_hooks` only matches on `bash` in the first line of the script. I added a `sh` key to `headers` and that seems to have resolved the issue at my end.

https://github.com/pre-commit/pre-commit/issues/2182

https://github.com/pre-commit/pre-commit/pull/2187/commits