### PR TITLE
add conftest.py

### DIFF
--- a/{{cookiecutter.project_name}}/tests/conftest.py
+++ b/{{cookiecutter.project_name}}/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Configuration for the pytest test suite."""
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Fixture for invoking command-line interfaces."""
+    return CliRunner()

--- a/{{cookiecutter.project_name}}/tests/test_main.py
+++ b/{{cookiecutter.project_name}}/tests/test_main.py
@@ -1,14 +1,7 @@
 """Test cases for the __main__ module."""
-import pytest
 from click.testing import CliRunner
 
 from {{cookiecutter.package_name}} import __main__
-
-
-@pytest.fixture
-def runner() -> CliRunner:
-    """Fixture for invoking command-line interfaces."""
-    return CliRunner()
 
 
 def test_main_succeeds(runner: CliRunner) -> None:


### PR DESCRIPTION
The [`pytest.fixture`](https://docs.pytest.org/en/7.0.x/reference/fixtures.html#reference-fixtures) should go in [conftest.py](https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files), apart from getting a better organization we avoid the `runner` name collision. 