### PR TITLE
📚 [conf] Ignore badgen.net when checking links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@ linkcheck_ignore = [
     "https://github.com/PyCQA/mccabe#",
     "https://github.com/cjolowicz/cookiecutter-hypermodern-python/releases/tag/",
     "https://cookiecutter-hypermodern-python.readthedocs.io",
+    "https://badgen.net/badge/status/alpha/d8624d",
 ]
 myst_enable_extensions = [
     "colon_fence",


### PR DESCRIPTION
Badgen frequently returns HTTP 500, failing CI.
