### PR TITLE
Remove prompt character from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 ## Usage
 
 ```console
-$ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2022.6.3
+cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout=2022.6.3
 ```
 
 ## Features


### PR DESCRIPTION
removed '$' so the command is correct in the convenience of directly copying to CLI

I am aware that the documentation also uses '$' as a marker for "this is a terminal input" and I guess it's by choice. 
The change proposed here in the repository readme is that it's a long phrase with possibilities of typos and should get users running with low friction. One frictionless way is to click the copy button of the code cell and paste in your terminal.