### PR TITLE
Improve Poetry + VSCode integration

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,6 +58,11 @@ Run an interactive Python session:
 $ poetry install
 $ poetry run python
 ```
+Some IDEs (e.g. Visual Studio Code) will not recognize the virtual environment created by `poetry`. Resolve this by creating the virtualenv within the project path:
+```console
+$ poetry config virtualenvs.in-project true
+```
+and reload your IDE as needed.
 
 ## Testing
 


### PR DESCRIPTION
See: https://stackoverflow.com/questions/59882884/vscode-doesnt-show-poetry-virtualenvs-in-select-interpreter-option

I have added a command that allows VSCode users to see and use the virtualenv created by Poetry inside the development environment.