### PR TITLE
Remove the line continuation char in the docs

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -213,8 +213,7 @@ by pointing Cookiecutter to its [GitHub repository][hypermodern python cookiecut
 Use the `--checkout` option with the [current stable release][2022.6.3]:
 
 ```console
-$ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-  --checkout="2022.6.3"
+$ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout="2022.6.3"
 ```
 
 Cookiecutter downloads the template,

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,8 +27,7 @@ based on the [Hypermodern Python] article series.
 ## Usage
 
 ```console
-$ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-  --checkout="2022.6.3"
+$ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout="2022.6.3"
 ```
 
 ## Features

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,8 +30,7 @@ It is recommended to set up Python 3.7, 3.8, 3.9, 3.10 using [pyenv].
 Generate a Python project:
 
 ```console
-$ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python \
-  --checkout="2022.6.3"
+$ cookiecutter gh:cjolowicz/cookiecutter-hypermodern-python --checkout="2022.6.3"
 ```
 
 Change to the root directory of your new project,


### PR DESCRIPTION
Because this does not work on Windows, and Windows users would get a negative user experience when copying and pasting the command from the docs without knowing or thinking of that problem.