### PR TITLE
Quote help wanted color

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -39,7 +39,7 @@
   color: 7057ff
 - name: help wanted
   description: Extra attention is needed
-  color: 008672
+  color: "008672"
 - name: invalid
   description: This doesn't seem right
   color: e4e669

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -86,6 +86,9 @@ $ nox -s pre-commit -- install
 1. Sign up at [GitHub].
 2. Create an empty repository for your project.
 3. Follow the instructions to push an existing repository from the command line.
+4. Make sure that the GitHub Actions have write permissions to the repository.
+   This is required for the release-drafter and labeler workflows to work. 
+   This setting can be found under Settings -> Actions -> General -> Workflow permissions -> Read and write permissions
 
 ### PyPI
 


### PR DESCRIPTION
The color `008672` is interpreted as `8672` which is not a valid string. Quoting this prevents the following error: 
```
Cannot create "help wanted" label: Invalid request. For 'properties/color', 8672 is not a string.
```