### PR TITLE
CI: Upgrade Poetry and nox-poetry

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -3,6 +3,6 @@ cookiecutter==2.1.1
 cutty==0.18.0
 nox==2022.1.7
 nox-poetry==1.0.1
-poetry==1.1.13
+poetry==1.3.2
 pre-commit==2.19.0
 virtualenv==20.14.1

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -2,7 +2,7 @@ pip==22.1.2
 cookiecutter==2.1.1
 cutty==0.18.0
 nox==2022.1.7
-nox-poetry==1.0.1
+nox-poetry==1.0.2
 poetry==1.3.2
 pre-commit==2.19.0
 virtualenv==20.14.1

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -2003,7 +2003,6 @@ The following options are enabled for strictness and enhanced output:
 - {option}`warn_unreachable <mypy --warn-unreachable>`
 - {option}`pretty <mypy --pretty>`
 - {option}`show_column_numbers <mypy --show-column-numbers>`
-- {option}`show_error_codes <mypy --show-error-codes>`
 - {option}`show_error_context <mypy --show-error-context>`
 
 (external-services)=


### PR DESCRIPTION
* Upgrade Poetry to fix an error because the project uses lock file format version 2.0.

* Remove broken link to `mypy --show-error-codes` from the documentation. The option still exists, but the documentation target is gone, and the behavior is the default with newer versions of mypy.

* Upgrade nox-poetry to fix broken builds due to a change in enum formatting in newer Python versions.