### PR TITLE
only run tests workflow when needed

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/tests.yml
@@ -1,8 +1,14 @@
 name: Tests
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
 
 jobs:
   tests:


### PR DESCRIPTION
- ignore files that don't need tests, e.g. files in `docs/` and `.md` files

closes #1331 